### PR TITLE
Fix path to server and add activation command

### DIFF
--- a/docs/management/start_stop.rst
+++ b/docs/management/start_stop.rst
@@ -18,7 +18,8 @@ commands:
 
 .. code-block:: bash
 
-    $ cd ~/auvsi_suas_competition/src/auvsi_suas_server
+    $ cd ~/interop/server
+    $ source venv/bin/activate
     $ python manage.py runserver 0.0.0.0:8080
 
 View the Server


### PR DESCRIPTION
Runserver will not work unless venv has been activated.