### PR TITLE
Enable and fix load tests

### DIFF
--- a/server/auvsi_suas/views/telemetry_test.py
+++ b/server/auvsi_suas/views/telemetry_test.py
@@ -3,6 +3,7 @@
 import datetime
 import iso8601
 import json
+import time
 from auvsi_suas.models import AerialPosition
 from auvsi_suas.models import GpsPosition
 from auvsi_suas.models import UasTelemetry

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -169,7 +169,7 @@ TEST_RUNNER = 'auvsi_suas.test_runner.AuvsiSuasTestRunner'
 TEST_ENABLE_PLOTTING = False
 
 # Whether to perform load tests (slower)
-TEST_ENABLE_LOADTEST = False
+TEST_ENABLE_LOADTEST = True
 
 # The time to execute each loadtest for
 TEST_LOADTEST_TIME = 10.0


### PR DESCRIPTION
Enable the load tests by default and fix the telemetry load test, which
was missing an import.

Fixes #5