### PR TITLE
Force Django to import all necessary modules before first request

### DIFF
--- a/server/server/wsgi.py
+++ b/server/server/wsgi.py
@@ -7,7 +7,8 @@ For more information on this file, see
 https://docs.djangoproject.com/en/1.6/howto/deployment/wsgi/
 """
 
-import logging
+from django.core.wsgi import get_wsgi_application
+from django.test import Client
 import os
 import sys
 
@@ -17,5 +18,11 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.settings")
 server_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path = [server_dir] + sys.path
 
-from django.core.wsgi import get_wsgi_application
 application = get_wsgi_application()
+
+# Django puts off loading many relevant modules until the first request
+# arrives. If the disk is very slow (e.g., when using Vagrant, see #8),
+# this introduces significant latency in the first request. By making a dummy
+# request here, we force Django to import everything it needs and improve
+# latency for the first real request.
+Client().get("/")


### PR DESCRIPTION
When running on Vagrant, the interop repo (which contains the server
script) is shared with the guest via the synced_folders Vagrant config.
Unfortunately, this folder can be very slow, so the first request can
have significant latency, which is occasionally long enough to make
requests time out, and tests fail.

We already tell Apache to do some preloading, which preloads most of
Django, but Django itself lazily loads most of the modules needed to
service requests only when the first request arrives.

By sending a dummy request in the WSGI setup, we ensure that the first
real request has low latency.

Fixes #8