### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+dist: trusty
+language: generic
+
+install:
+  # Travis CI does not make the home directory world readable by default,
+  # which prevents Apache from reading the server source.
+  - sudo chmod 755 /home/travis/
+  - ./setup/setup.sh
+
+script:
+  - ./test.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 AUVSI SUAS Interoperability
 ===========================
 
-[![Documentation](https://readthedocs.org/projects/auvsi-suas-competition-interoperability-system/badge/?version=latest)](http://auvsi-suas-competition-interoperability-system.readthedocs.org/en/latest/?badge=latest)
+[![Documentation](https://readthedocs.org/projects/auvsi-suas-competition-interoperability-system/badge/?version=latest)](http://auvsi-suas-competition-interoperability-system.readthedocs.org/en/latest/?badge=latest) [![Build Status](https://travis-ci.org/auvsi-suas/interop.svg)](https://travis-ci.org/auvsi-suas/interop)
 
 This is the repository for the Association for Unmanned Vehicle Systems
 International (AUVSI) Student Unmanned Aerial System (SUAS) Competition. It

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -41,8 +41,11 @@ sudo ln -snf ${REPO} /interop
 # Update the package list
 log "Updating package list and upgrading packages..."
 sudo apt-get -y update
-# Upgrade old packages
-sudo apt-get -y upgrade
+if [[ ! -v TRAVIS ]]; then
+    # Upgrade old packages
+    # Travis CI recommends againsts apt-get upgrade for speed.
+    sudo apt-get -y upgrade
+fi
 
 # Install Puppet
 log "Installing Puppet and modules..."


### PR DESCRIPTION
The config uses the exact same Puppet setup as a normal installation,
and runs the typical tests. It takes about 5 minutes to run.

In October, Travis finally added 14.04 as a base distro. My previous attempts to get our automated setup working on 12.04 were painful to say the least.