### PR TITLE
Install PyYAML for server

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -7,6 +7,7 @@ matplotlib
 numpy
 pillow
 psycopg2
+PyYAML # for loaddata
 scipy
 simplekml==1.2.7
 ipaddress


### PR DESCRIPTION
PyYAML is required for ``loaddata`` to be able to load our test fixture
into the database.

We were missing this dependency before, and simply relied on the system
having it installed by default.

Fixes #7