### PR TITLE
Create a setup log file

### DIFF
--- a/setup/.gitignore
+++ b/setup/.gitignore
@@ -1,1 +1,2 @@
 .vagrant/
+*.log

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -34,6 +34,9 @@ function ensure_puppet_module() {
     sudo puppet module upgrade ${module}
 }
 
+# Save all output to a log file.
+exec &> >(tee ${SETUP}/setup-$(date +%F-%H-%M-%S).log)
+
 # Create soft link from repo to standardize scripts
 log "Creating softlinks..."
 sudo ln -snf ${REPO} /interop


### PR DESCRIPTION
In addition to displaying setup output on the screen, redirect it to a
log file. This log will be helpful if teams need to upload setup output
for support.