### PR TITLE
Display raw ID fields for models with many instances

### DIFF
--- a/server/auvsi_suas/admin.py
+++ b/server/auvsi_suas/admin.py
@@ -19,16 +19,48 @@ class LargeDataModelAdmin(admin.ModelAdmin):
     show_full_result_count = False
 
 # Register models for admin page
-admin.site.register(AerialPosition, LargeDataModelAdmin)
+
+# Only display raw ID fields for ForeignKeys which may contain large amounts
+# of data.
+
+
+@admin.register(AerialPosition)
+class AerialPositionModelAdmin(LargeDataModelAdmin):
+    raw_id_fields = ("gps_position", )
+
+
+@admin.register(MissionConfig)
+class MissionConfigModelAdmin(admin.ModelAdmin):
+    raw_id_fields = ("home_pos", "emergent_last_known_pos",
+                     "off_axis_target_pos", "sric_pos",
+                     "ir_primary_target_pos", "ir_secondary_target_pos",
+                     "air_drop_pos")
+
+
+@admin.register(StationaryObstacle)
+class StationaryObstacleModelAdmin(LargeDataModelAdmin):
+    raw_id_fields = ("gps_position", )
+
+
+@admin.register(Target)
+class TargetModelAdmin(LargeDataModelAdmin):
+    raw_id_fields = ("location", )
+
+
+@admin.register(UasTelemetry)
+class UasTelemetryModelAdmin(LargeDataModelAdmin):
+    raw_id_fields = ("uas_position", )
+
+
+@admin.register(Waypoint)
+class WaypointModelAdmin(LargeDataModelAdmin):
+    raw_id_fields = ("position", )
+
+# These don't require any raw fields.
 admin.site.register(FlyZone)
 admin.site.register(GpsPosition, LargeDataModelAdmin)
-admin.site.register(MissionConfig)
 admin.site.register(MovingObstacle)
 admin.site.register(ObstacleAccessLog, LargeDataModelAdmin)
 admin.site.register(ServerInfo)
 admin.site.register(ServerInfoAccessLog, LargeDataModelAdmin)
-admin.site.register(StationaryObstacle)
-admin.site.register(UasTelemetry, LargeDataModelAdmin)
 admin.site.register(TakeoffOrLandingEvent)
-admin.site.register(Target)
-admin.site.register(Waypoint)


### PR DESCRIPTION
Certain models, such as GpsPosition and AerialPosition may have
thousands or hundreds of thousands of entries once a significant amount
of telemetry has been to the server.

By default, the admin interface will enumerate all options for these
ForeignKeys. This is infeasible when there are too many instances, so
just display a raw ID field instead. There will be a search button next
to the box, where a specific instance can be searched for or created.

References #13