### PR TITLE
Remove IR target positions

### DIFF
--- a/server/auvsi_suas/admin.py
+++ b/server/auvsi_suas/admin.py
@@ -32,9 +32,7 @@ class AerialPositionModelAdmin(LargeDataModelAdmin):
 @admin.register(MissionConfig)
 class MissionConfigModelAdmin(admin.ModelAdmin):
     raw_id_fields = ("home_pos", "emergent_last_known_pos",
-                     "off_axis_target_pos", "sric_pos",
-                     "ir_primary_target_pos", "ir_secondary_target_pos",
-                     "air_drop_pos")
+                     "off_axis_target_pos", "sric_pos", "air_drop_pos")
 
 
 @admin.register(StationaryObstacle)

--- a/server/auvsi_suas/fixtures/testdata/sample_mission.json
+++ b/server/auvsi_suas/fixtures/testdata/sample_mission.json
@@ -885,8 +885,6 @@
             156
         ],
         "emergent_last_known_pos": 324,
-        "ir_primary_target_pos": 324,
-        "ir_secondary_target_pos": 324,
         "sric_pos": 324,
         "search_grid_points": [
             150

--- a/server/auvsi_suas/migrations/0011_remove_ir.py
+++ b/server/auvsi_suas/migrations/0011_remove_ir.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [('auvsi_suas', '0010_missionconfig_fly_zones')]
+
+    operations = [
+        migrations.RemoveField(model_name='missionconfig',
+                               name='ir_primary_target_pos'),
+        migrations.RemoveField(model_name='missionconfig',
+                               name='ir_secondary_target_pos'),
+    ]

--- a/server/auvsi_suas/models/mission_config.py
+++ b/server/auvsi_suas/models/mission_config.py
@@ -59,16 +59,6 @@ class MissionConfig(models.Model):
     sric_pos = models.ForeignKey(GpsPosition,
                                  related_name='missionconfig_sric_pos')
 
-    # The IR primary target position
-    ir_primary_target_pos = models.ForeignKey(
-        GpsPosition,
-        related_name='missionconfig_ir_primary_target_pos')
-
-    # The IR secondary target position
-    ir_secondary_target_pos = models.ForeignKey(
-        GpsPosition,
-        related_name='missionconfig_ir_secondary_target_pos')
-
     # The air drop position
     air_drop_pos = models.ForeignKey(GpsPosition,
                                      related_name='missionconfig_air_drop_pos')
@@ -100,16 +90,13 @@ class MissionConfig(models.Model):
             'MissionConfig (pk:%s, is_active: %s, home_pos:%s, '
             'mission_waypoints:[%s], search_grid:[%s], '
             'emergent_lkp:%s, off_axis:%s, '
-            'sric_pos:%s, ir_primary_pos:%s, ir_secondary_pos:%s, '
-            'air_drop_pos:%s, server_info:%s, stationary_obstacles:%s, '
-            'moving_obstacles:%s)' %
+            'sric_pos:%s, air_drop_pos:%s, server_info:%s, '
+            'stationary_obstacles:%s, moving_obstacles:%s)' %
             (str(self.pk), str(self.is_active), self.home_pos.__unicode__(),
              mission_waypoints_str, search_grid_str,
              self.emergent_last_known_pos.__unicode__(),
              self.off_axis_target_pos.__unicode__(),
              self.sric_pos.__unicode__(),
-             self.ir_primary_target_pos.__unicode__(),
-             self.ir_secondary_target_pos.__unicode__(),
              self.air_drop_pos.__unicode__(), self.server_info.__unicode__(),
              stationary_obstacles_str, moving_obstacles_str))
 
@@ -259,14 +246,6 @@ class MissionConfig(models.Model):
                 'latitude': self.sric_pos.latitude,
                 'longitude': self.sric_pos.longitude,
             },
-            'ir_primary_target_pos': {
-                'latitude': self.ir_primary_target_pos.latitude,
-                'longitude': self.ir_primary_target_pos.longitude,
-            },
-            'ir_secondary_target_pos': {
-                'latitude': self.ir_secondary_target_pos.latitude,
-                'longitude': self.ir_secondary_target_pos.longitude,
-            },
             'air_drop_pos': {
                 'latitude': self.air_drop_pos.latitude,
                 'longitude': self.air_drop_pos.longitude,
@@ -352,8 +331,6 @@ class MissionConfig(models.Model):
             'Emergent LKP': self.emergent_last_known_pos,
             'Off Axis': self.off_axis_target_pos,
             'SRIC': self.sric_pos,
-            'IR Primary': self.ir_primary_target_pos,
-            'IR Secondary': self.ir_secondary_target_pos,
             'Air Drop': self.air_drop_pos,
         }
         for key, point in locations.iteritems():

--- a/server/auvsi_suas/models/mission_config_test.py
+++ b/server/auvsi_suas/models/mission_config_test.py
@@ -49,8 +49,6 @@ class TestMissionConfigModel(TestCase):
         config.emergent_last_known_pos = pos
         config.off_axis_target_pos = pos
         config.sric_pos = pos
-        config.ir_primary_target_pos = pos
-        config.ir_secondary_target_pos = pos
         config.air_drop_pos = pos
         config.server_info = self.info
         config.save()
@@ -74,8 +72,6 @@ class TestMissionConfigModel(TestCase):
         config.emergent_last_known_pos = gpos
         config.off_axis_target_pos = gpos
         config.sric_pos = gpos
-        config.ir_primary_target_pos = gpos
-        config.ir_secondary_target_pos = gpos
         config.air_drop_pos = gpos
         config.server_info = self.info
         config.save()
@@ -302,18 +298,6 @@ class TestMissionConfigModelSampleMission(TestCase):
         self.assertEqual(10.0, data['sric_pos']['latitude'])
         self.assertEqual(100.0, data['sric_pos']['longitude'])
 
-        self.assertIn('ir_primary_target_pos', data)
-        self.assertIn('latitude', data['ir_primary_target_pos'])
-        self.assertIn('longitude', data['ir_primary_target_pos'])
-        self.assertEqual(10.0, data['ir_primary_target_pos']['latitude'])
-        self.assertEqual(100.0, data['ir_primary_target_pos']['longitude'])
-
-        self.assertIn('ir_secondary_target_pos', data)
-        self.assertIn('latitude', data['ir_secondary_target_pos'])
-        self.assertIn('longitude', data['ir_secondary_target_pos'])
-        self.assertEqual(10.0, data['ir_secondary_target_pos']['latitude'])
-        self.assertEqual(100.0, data['ir_secondary_target_pos']['longitude'])
-
         self.assertIn('air_drop_pos', data)
         self.assertIn('latitude', data['air_drop_pos'])
         self.assertIn('longitude', data['air_drop_pos'])
@@ -353,10 +337,8 @@ class TestMissionConfigModelSampleMission(TestCase):
         data = kml.kml()
         names = [
             'Off Axis',
-            'IR Secondary',
             'SRIC',
             'Home Position',
-            'IR Primary',
             'Air Drop',
             'Emergent LKP',
             'Search Area',

--- a/server/auvsi_suas/static/auvsi_suas/components/mission-scene/mission-scene.js
+++ b/server/auvsi_suas/static/auvsi_suas/components/mission-scene/mission-scene.js
@@ -272,7 +272,6 @@ MissionScene.prototype.addMissionSceneElements_ = function(mission, scene) {
     // Add mission components to scene.
     var missionComponents = [
         mission.air_drop_pos, mission.emergent_last_known_pos,
-        mission.ir_primary_target_pos, mission.ir_secondary_target_pos,
         mission.off_axis_target_pos, mission.sric_pos];
     for (var i = 0; i < missionComponents.length; i++) {
         var component = missionComponents[i];

--- a/server/auvsi_suas/views/auvsi_admin/live_kml_test.py
+++ b/server/auvsi_suas/views/auvsi_admin/live_kml_test.py
@@ -52,8 +52,6 @@ class TestGenerateLiveKMLNoFixture(TestGenerateLiveKMLCommon):
         config.emergent_last_known_pos = pos
         config.off_axis_target_pos = pos
         config.sric_pos = pos
-        config.ir_primary_target_pos = pos
-        config.ir_secondary_target_pos = pos
         config.air_drop_pos = pos
         config.server_info = info
         config.save()

--- a/server/auvsi_suas/views/clear_cache_test.py
+++ b/server/auvsi_suas/views/clear_cache_test.py
@@ -39,8 +39,6 @@ class TestClearCache(TestCase):
         config.emergent_last_known_pos = pos
         config.off_axis_target_pos = pos
         config.sric_pos = pos
-        config.ir_primary_target_pos = pos
-        config.ir_secondary_target_pos = pos
         config.air_drop_pos = pos
         config.server_info = info
         config.save()

--- a/server/auvsi_suas/views/missions_test.py
+++ b/server/auvsi_suas/views/missions_test.py
@@ -46,8 +46,6 @@ class TestMissionForRequest(TestCase):
         config.emergent_last_known_pos = pos
         config.off_axis_target_pos = pos
         config.sric_pos = pos
-        config.ir_primary_target_pos = pos
-        config.ir_secondary_target_pos = pos
         config.air_drop_pos = pos
         config.server_info = info
         return config
@@ -248,19 +246,6 @@ class TestMissionsViewSampleMission(TestMissionsViewCommon):
         self.assertIn('longitude', data[0]['sric_pos'])
         self.assertEqual(10.0, data[0]['sric_pos']['latitude'])
         self.assertEqual(100.0, data[0]['sric_pos']['longitude'])
-
-        self.assertIn('ir_primary_target_pos', data[0])
-        self.assertIn('latitude', data[0]['ir_primary_target_pos'])
-        self.assertIn('longitude', data[0]['ir_primary_target_pos'])
-        self.assertEqual(10.0, data[0]['ir_primary_target_pos']['latitude'])
-        self.assertEqual(100.0, data[0]['ir_primary_target_pos']['longitude'])
-
-        self.assertIn('ir_secondary_target_pos', data[0])
-        self.assertIn('latitude', data[0]['ir_secondary_target_pos'])
-        self.assertIn('longitude', data[0]['ir_secondary_target_pos'])
-        self.assertEqual(10.0, data[0]['ir_secondary_target_pos']['latitude'])
-        self.assertEqual(100.0,
-                         data[0]['ir_secondary_target_pos']['longitude'])
 
         self.assertIn('air_drop_pos', data[0])
         self.assertIn('latitude', data[0]['air_drop_pos'])

--- a/server/auvsi_suas/views/obstacles_test.py
+++ b/server/auvsi_suas/views/obstacles_test.py
@@ -103,8 +103,6 @@ class TestObstaclesViewCommon(TestCase):
         config.emergent_last_known_pos = pos
         config.off_axis_target_pos = pos
         config.sric_pos = pos
-        config.ir_primary_target_pos = pos
-        config.ir_secondary_target_pos = pos
         config.air_drop_pos = pos
         config.server_info = info
         config.save()

--- a/server/auvsi_suas/views/server_info_test.py
+++ b/server/auvsi_suas/views/server_info_test.py
@@ -56,8 +56,6 @@ class TestServerInfoView(TestCase):
         self.mission.emergent_last_known_pos = gpos
         self.mission.off_axis_target_pos = gpos
         self.mission.sric_pos = gpos
-        self.mission.ir_primary_target_pos = gpos
-        self.mission.ir_secondary_target_pos = gpos
         self.mission.air_drop_pos = gpos
         self.mission.server_info = self.info
         self.mission.save()

--- a/server/fixtures/test_fixture.yaml
+++ b/server/fixtures/test_fixture.yaml
@@ -82,8 +82,6 @@
     air_drop_pos: 4
     emergent_last_known_pos: 2
     home_pos: 1
-    ir_primary_target_pos: 5
-    ir_secondary_target_pos: 3
     is_active: true
     mission_waypoints: [1]
     off_axis_target_pos: 3


### PR DESCRIPTION
The 2016 rules include no IR targets. Remove them from the
MissionConfig, KML, and frontend.

Fixes #21