### PR TITLE
Avoid the latest virtualenv wheel

### DIFF
--- a/setup/puppet_files/auvsi_suas/manifests/base.pp
+++ b/setup/puppet_files/auvsi_suas/manifests/base.pp
@@ -35,7 +35,11 @@ class auvsi_suas::base {
     # version of pip outside of a virtualenv, so we must install with a manual
     # command.
     exec { 'install virtualenv-3.4' :
-        command => 'pip3 install --upgrade virtualenv',
+        # FIXME(pypa/virtualenv#851): The current version of the virtualenv
+        # wheel creates a virtualenv-3.5 binary, regardless of Python version.
+        # Workaround the issue by avoiding the wheel.
+        # https://github.com/pypa/virtualenv/issues/851
+        command => 'pip3 install --upgrade --no-use-wheel virtualenv',
         user => root,
         require => Package['python3-pip'],
     }


### PR DESCRIPTION
The virtualenv 14.0.1 package wheel creates a virtualenv-3.5 binary,
regardless of Python version. Since we are running Python 3.4, this
breaks later setup steps. By avoiding the wheel (and using the tar
instead), we avoid the issue.

See the virtualenv issue at pypa/virtualenv#851
(https://github.com/pypa/virtualenv/issues/851).

Fixes #26