### PR TITLE
Remove interpreter line execution to support Vagrant-Windows.

### DIFF
--- a/docs/setup/machine_or_vm.rst
+++ b/docs/setup/machine_or_vm.rst
@@ -52,7 +52,7 @@ setup:
 .. code-block:: bash
 
     $ cd ~/interop/setup
-    $ ./setup.sh
+    $ bash setup.sh
 
 Manual Database Setup
 ---------------------

--- a/docs/setup/testing.rst
+++ b/docs/setup/testing.rst
@@ -10,13 +10,13 @@ To run the tests execute the following commands:
 
 .. code-block:: bash
 
-    $ ~/interop/test.sh
+    $ bash /interop/test.sh
 
 Or from outside Vagrant VM:
 
 .. code-block:: bash
 
-    $ vagrant ssh -c "/interop/test.sh"
+    $ vagrant ssh -c "bash /interop/test.sh"
 
 The tests have executed successfully if you see these lines::
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -39,7 +39,7 @@ manifest. A couple of ports are forwarded from the guest to the host:
 A single command can be executed on the host to run all tests:
 
 ``` sh
-vagrant ssh -c "/interop/test.sh"
+vagrant ssh -c "bash /interop/test.sh"
 ```
 
 
@@ -50,5 +50,5 @@ To setup a physical or prebuilt virtual machine, change the working directory
 to this directory, and execute script:
 
 ``` sh
-./setup.sh
+bash setup.sh
 ```

--- a/setup/Vagrantfile
+++ b/setup/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Use automated setup script
   config.vm.provision :shell do |shell|
     shell.inline = "cd /home/vagrant/interop/setup;
-                    ./setup.sh;"
+                    bash setup.sh;"
   end
 
 end

--- a/test.sh
+++ b/test.sh
@@ -38,7 +38,7 @@ cd /interop/server/auvsi_suas/static/auvsi_suas
 
 echo "Testing JavaScript Frontend..."
 
-./test_with_phantomjs.sh
+bash test_with_phantomjs.sh
 frontend=$?
 
 echo -e "\n=====================================================================\n"


### PR DESCRIPTION
Execute scripts with interpreter type.

For #28 