### PR TITLE
Work around sphinx-doc/sphinx#2280

### DIFF
--- a/docs/spec.rst
+++ b/docs/spec.rst
@@ -778,9 +778,13 @@ Targets
 
    **Example response**:
 
+   .. FIXME(sphinx-doc/sphinx#2280): The Content-Type here is not particularly
+      relevant, but otherwise the sourcecode block will fail to lex.
+
    .. sourcecode:: http
 
       HTTP/1.1 200 OK
+      Content-Type: text/html
 
       Target deleted.
 


### PR DESCRIPTION
The docs are currently building with warnings because one HTTP
sourcecode block cannot be highlighted. The root cause is
sphinx-doc/sphinx#2280. Once that is fixed, the block should be fine as
previously written. Until then, explicitly add a Content-Type line to
avoid the bug.

Fixes #41