### PR TITLE
Don't install virtualenv-3.4

### DIFF
--- a/setup/puppet_files/auvsi_suas/manifests/base.pp
+++ b/setup/puppet_files/auvsi_suas/manifests/base.pp
@@ -30,18 +30,4 @@ class auvsi_suas::base {
     package { $package_deps:
         ensure => "latest",
     }
-
-    # Ubuntu 14.04 comes with a broken virtualenv, so it must be installed
-    # from pip. Better yet, python::pip can't use a non-system (i.e., Python 2)
-    # version of pip outside of a virtualenv, so we must install with a manual
-    # command.
-    exec { 'install virtualenv-3.4' :
-        # FIXME(pypa/virtualenv#851): The current version of the virtualenv
-        # wheel creates a virtualenv-3.5 binary, regardless of Python version.
-        # Workaround the issue by avoiding the wheel.
-        # https://github.com/pypa/virtualenv/issues/851
-        command => 'pip3 install --upgrade --no-use-wheel virtualenv',
-        user => root,
-        require => Package['python3-pip'],
-    }
 }


### PR DESCRIPTION
The latest version (1.11.0) of the stankevich-python Puppet module will
specify the appropriate version of Python to use to the system
virtualenv install. It is no longer necessary to use a separate
virtualenv installation for Python 3.

This is the recommended path forward from pypa/virtualenv#851, as the
versioned virtualenv binaries are likely going away.