### PR TITLE
Add MissionClockEvent to track mission clock time.

### DIFF
--- a/server/auvsi_suas/migrations/0012_missionclockevent.py
+++ b/server/auvsi_suas/migrations/0012_missionclockevent.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [('auvsi_suas', '0011_remove_ir'), ]
+
+    operations = [
+        migrations.CreateModel(
+            name='MissionClockEvent',
+            fields=[
+                ('accesslog_ptr',
+                 models.OneToOneField(parent_link=True,
+                                      auto_created=True,
+                                      primary_key=True,
+                                      serialize=False,
+                                      to='auvsi_suas.AccessLog')),
+                ('team_on_clock', models.BooleanField()),
+                ('team_on_timeout', models.BooleanField()),
+            ],
+            bases=('auvsi_suas.accesslog', ), ),
+    ]

--- a/server/auvsi_suas/models/__init__.py
+++ b/server/auvsi_suas/models/__init__.py
@@ -2,6 +2,7 @@ from aerial_position import AerialPosition
 from access_log import AccessLog
 from fly_zone import FlyZone
 from gps_position import GpsPosition
+from mission_clock_event import MissionClockEvent
 from mission_config import MissionConfig
 from moving_obstacle import MovingObstacle
 from obstacle_access_log import ObstacleAccessLog

--- a/server/auvsi_suas/models/mission_clock_event.py
+++ b/server/auvsi_suas/models/mission_clock_event.py
@@ -1,0 +1,22 @@
+"""Mission Clock event model."""
+
+from access_log import AccessLog
+from time_period import TimePeriod
+from django.db import models
+from django.utils import timezone
+
+
+class MissionClockEvent(AccessLog):
+    """Marker for a team going on/off mission clock."""
+    # Whether the team is now on the mission clock.
+    team_on_clock = models.BooleanField()
+    # Whether the team is now in a timeout.
+    team_on_timeout = models.BooleanField()
+
+    def __unicode__(self):
+        """Descriptive text for use in displays."""
+        return unicode('MissionClockEvent (pk:%s, user:%s, timestamp:%s, '
+                       'team_on_clock:%s, team_on_timeout:%s)' %
+                       (str(self.pk), self.user.__unicode__(),
+                        str(self.timestamp), str(self.team_on_clock),
+                        str(self.team_on_timeout)))

--- a/server/auvsi_suas/models/mission_clock_event_test.py
+++ b/server/auvsi_suas/models/mission_clock_event_test.py
@@ -1,0 +1,18 @@
+"""Tests for the mission_clock_event module."""
+
+import datetime
+from auvsi_suas.models import MissionClockEvent
+from auvsi_suas.models.access_log_test import TestAccessLogCommon
+from django.utils import timezone
+
+
+class TestMissionClockEventModel(TestAccessLogCommon):
+    """Tests the MissionClockEvent model."""
+
+    def test_unicode(self):
+        """Tests the unicode method executes."""
+        log = MissionClockEvent(user=self.user1,
+                                team_on_clock=True,
+                                team_on_timeout=False)
+        log.save()
+        self.assertIsNotNone(log.__unicode__())

--- a/server/auvsi_suas/models/takeoff_or_landing_event.py
+++ b/server/auvsi_suas/models/takeoff_or_landing_event.py
@@ -13,7 +13,7 @@ class TakeoffOrLandingEvent(AccessLog):
 
     def __unicode__(self):
         """Descriptive text for use in displays."""
-        return unicode('TakeoffOrLandingEvent (pk%s, user:%s, timestamp:%s, '
+        return unicode('TakeoffOrLandingEvent (pk:%s, user:%s, timestamp:%s, '
                        'uas_in_air:%s)' %
                        (str(self.pk), self.user.__unicode__(),
                         str(self.timestamp), str(self.uas_in_air)))


### PR DESCRIPTION
For #45 

Following this PR:
1) Refactor [TakeoffOrLandingEvent.flights](https://github.com/auvsi-suas/interop/blob/master/server/auvsi_suas/models/takeoff_or_landing_event.py#L22) so generic implementation it is part of  [TimePeriod](https://github.com/auvsi-suas/interop/blob/master/server/auvsi_suas/models/time_period.py).
2) Refactor [TakeoffOrLandingEvent.user_in_air](https://github.com/auvsi-suas/interop/blob/master/server/auvsi_suas/models/takeoff_or_landing_event.py#L64) so it uses a function in `AccessLog` which gets the latest access log before a time. 
3) Add a method similar to `flights` and `user_in_air` to `MissionClockEvent` in order to get the on-mission-clock periods, on timeout periods, and whether the user is on mission clock / timeout.
4) Add grading of time-on-mission-clock.
5) In future target grading interfaces, hide submitted targets for users which are either on mission clock or on timeout.