### PR TITLE
Use namedtuple as base client type. Add id,user to Target.

### DIFF
--- a/client/interop/client.py
+++ b/client/interop/client.py
@@ -89,10 +89,7 @@ class Client(object):
         """
         r = self.get('/api/server_info')
         d = r.json()
-
-        return ServerInfo(message=d['message'],
-                          message_timestamp=d['message_timestamp'],
-                          server_time=d['server_time'])
+        return ServerInfo(**d)
 
     def post_telemetry(self, telem):
         """POST new telemetry.
@@ -104,7 +101,7 @@ class Client(object):
             InteropError: Error from server
             requests.Timeout: Request timeout
         """
-        self.post('/api/telemetry', data=telem.serialize())
+        self.post('/api/telemetry', data=telem._asdict())
 
     def get_obstacles(self):
         """GET obstacles.
@@ -123,19 +120,11 @@ class Client(object):
 
         stationary = []
         for o in d['stationary_obstacles']:
-            s = StationaryObstacle(latitude=o['latitude'],
-                                   longitude=o['longitude'],
-                                   cylinder_radius=o['cylinder_radius'],
-                                   cylinder_height=o['cylinder_height'])
-            stationary.append(s)
+            stationary.append(StationaryObstacle(**o))
 
         moving = []
         for o in d['moving_obstacles']:
-            m = MovingObstacle(latitude=o['latitude'],
-                               longitude=o['longitude'],
-                               altitude_msl=o['altitude_msl'],
-                               sphere_radius=o['sphere_radius'])
-            moving.append(m)
+            moving.append(MovingObstacle(**o))
 
         return stationary, moving
 

--- a/client/interop/client_test.py
+++ b/client/interop/client_test.py
@@ -37,7 +37,7 @@ class TestClientLoggedOut(unittest.TestCase):
         """Test connection timeout"""
         # We are assuming that there is no machine at this address.
         addr = "http://10.255.255.254"
-        timeout = 0.1
+        timeout = 0.0001
         with self.assertRaises(requests.Timeout):
             Client(addr, username, password, timeout=timeout)
         with self.assertRaises(requests.Timeout):
@@ -75,10 +75,10 @@ class TestClient(unittest.TestCase):
 
     def test_post_telemetry(self):
         """Test sending some telemetry."""
-        t = Telemetry(latitude=38,
-                      longitude=-76,
-                      altitude_msl=100,
-                      uas_heading=90)
+        t = Telemetry(latitude=38.0,
+                      longitude=-76.0,
+                      altitude_msl=100.0,
+                      uas_heading=90.0)
 
         # Raises an exception on error.
         self.client.post_telemetry(t)
@@ -86,13 +86,13 @@ class TestClient(unittest.TestCase):
 
     def test_post_bad_telemetry(self):
         """Test sending some (incorrect) telemetry."""
-        t0 = Telemetry(latitude=38,
-                       longitude=-76,
-                       altitude_msl=100,
-                       uas_heading=90)
+        t0 = Telemetry(latitude=38.0,
+                       longitude=-76.0,
+                       altitude_msl=100.0,
+                       uas_heading=90.0)
         # The Telemetry constructor prevents us from passing invalid
         # values, but we can still screw things up in an update
-        t0.latitude = 'baz'
+        t0 = t0._replace(latitude='baz')
         with self.assertRaises(InteropError):
             self.client.post_telemetry(t0)
         with self.assertRaises(InteropError):
@@ -101,10 +101,10 @@ class TestClient(unittest.TestCase):
         # We only accept Telemetry objects (or objects that behave like
         # Telemetry, not dicts.
         t1 = {
-            'latitude': 38,
-            'longitude': -76,
-            'altitude_msl': 100,
-            'uas_heading': 90
+            'latitude': 38.0,
+            'longitude': -76.0,
+            'altitude_msl': 100.0,
+            'uas_heading': 90.0
         }
         with self.assertRaises(AttributeError):
             self.client.post_telemetry(t1)
@@ -125,19 +125,19 @@ class TestClient(unittest.TestCase):
 
         # Lat, lon, and altitude of the moving obstacles change, so we don't
         # check those.
-        self.assertEqual(50, moving[0].sphere_radius)
-        self.assertEqual(50, async_moving[0].sphere_radius)
+        self.assertEqual(50.0, moving[0].sphere_radius)
+        self.assertEqual(50.0, async_moving[0].sphere_radius)
 
         radii = [o.cylinder_radius for o in stationary]
         async_radii = [o.cylinder_radius for o in async_stationary]
-        self.assertIn(50, radii)
-        self.assertIn(50, async_radii)
-        self.assertIn(150, radii)
-        self.assertIn(150, async_radii)
+        self.assertIn(50.0, radii)
+        self.assertIn(50.0, async_radii)
+        self.assertIn(150.0, radii)
+        self.assertIn(150.0, async_radii)
 
         heights = [o.cylinder_height for o in stationary]
-        self.assertIn(300, heights)
-        self.assertIn(200, heights)
+        self.assertIn(300.0, heights)
+        self.assertIn(200.0, heights)
         async_heights = [o.cylinder_height for o in async_stationary]
-        self.assertIn(300, async_heights)
-        self.assertIn(200, async_heights)
+        self.assertIn(300.0, async_heights)
+        self.assertIn(200.0, async_heights)

--- a/client/interop/types.py
+++ b/client/interop/types.py
@@ -5,85 +5,92 @@ requires. They include input validation, making a best-effort to ensure
 values will be accepted by the server.
 """
 
+from collections import namedtuple
+from collections import OrderedDict
 import dateutil.parser
 import re
 import sys
+
+
+def check_type(obj, obj_type):
+    """Asserts that the obj is of the given type.
+
+    Raises:
+        ValueError: Invalid type.
+    """
+    if not isinstance(obj, obj_type):
+        raise ValueError('Object (%s) is not the type %s' % (obj, obj_type))
+
+
+def check_bounds(value, min_value, max_value):
+    """Assert that the given value is within the range.
+
+    Raises:
+        ValueError: Out of range.
+    """
+    if value < min_value or value > max_value:
+        raise ValueError('Value (%f) out of range [%f, %f]' %
+                         (value, min_value, max_value))
 
 
 def check_latitude(lat):
     """Assert that latitude is valid.
 
     Raises:
-        ValueError: Latitude out of range
+        ValueError: Latitude out of range.
     """
-    if lat < -90 or lat > 90:
-        raise ValueError('Latitude (%f) out of range [-90 - 90]' % lat)
+    check_bounds(lat, -90, 90)
 
 
 def check_longitude(lon):
     """Assert that longitude is valid.
 
     Raises:
-        ValueError: Longitude out of range
+        ValueError: Longitude out of range.
     """
-    if lon < -180 or lon > 180:
-        raise ValueError('Longitude (%f) out of range [-180, 180]' % lon)
+    check_bounds(lon, -180, 180)
 
 
-class Serializable(object):
-    """ Serializable is a simple base class which provides basic
-    'serialization' (a simple dict) of a subset of attributes the inheriting
-    class.
+def check_heading(heading):
+    """Asserts that heading is valid.
 
-    By serializing only specified attributes, other attributes can be utilized
-    by the class (or its subclasses) without being included in the serialized
-    dict.
+    Raises:
+        ValueError: Heading out of range.
     """
-
-    def __init__(self, attrs):
-        """Initialize attributes to serialize
-
-        Args:
-            attrs: List of string attribute names to serialize.
-        """
-        self.attrs = attrs
-
-    def serialize(self):
-        """Serialize the current state of the object."""
-        return {k: self.__dict__[k] for k in self.attrs}
+    check_bounds(heading, 0, 360)
 
 
-class Telemetry(Serializable):
+class Telemetry(
+        namedtuple('Telemetry',
+                   ['latitude', 'longitude', 'altitude_msl', 'uas_heading'])):
     """UAS Telemetry at a single point in time.
 
     Attributes:
         latitude: Latitude in decimal degrees.
         longitude: Longitude in decimal degrees.
         altitude_msl: Altitude MSL in feet.
-        uas_heading: Aircraft heading in degrees (0-360).
+        uas_heading: Aircraft heading in degrees [0, 360].
 
     Raises:
-        ValueError: Argument not convertable to float or out of range.
+        ValueError: Argument not valid.
     """
 
-    def __init__(self, latitude, longitude, altitude_msl, uas_heading):
-        super(Telemetry, self).__init__(['latitude', 'longitude',
-                                         'altitude_msl', 'uas_heading'])
-
-        self.latitude = float(latitude)
-        self.longitude = float(longitude)
-        self.altitude_msl = float(altitude_msl)
-        self.uas_heading = float(uas_heading)
+    def __init__(self, *args, **kwargs):
+        check_type(self.latitude, float)
+        check_type(self.longitude, float)
+        check_type(self.altitude_msl, float)
+        check_type(self.uas_heading, float)
 
         check_latitude(self.latitude)
         check_longitude(self.longitude)
+        check_heading(self.uas_heading)
 
-        if self.uas_heading < 0 or self.uas_heading > 360:
-            raise ValueError('Heading (%f) out of range [0, 360]' %
-                             self.uas_heading)
+    def _asdict(self):
+        return OrderedDict(zip(self._fields, self))
 
 
-class ServerInfo(Serializable):
+class ServerInfo(namedtuple('ServerInfo',
+                            ['message', 'message_timestamp', 'server_time'])):
     """Server information to be displayed to judges.
 
     Attributes:
@@ -95,16 +102,17 @@ class ServerInfo(Serializable):
         TypeError, ValueError: Message or server timestamp could not be parsed.
     """
 
-    def __init__(self, message, message_timestamp, server_time):
-        super(ServerInfo, self).__init__(['message', 'message_timestamp',
-                                          'server_time'])  # yapf: disable
+    def __new__(cls, message, message_timestamp, server_time):
+        return super(ServerInfo, cls).__new__(
+            cls,
+            message=message,
+            message_timestamp=dateutil.parser.parse(message_timestamp),
+            server_time=dateutil.parser.parse(server_time))
 
-        self.message = message
-        self.message_timestamp = dateutil.parser.parse(message_timestamp)
-        self.server_time = dateutil.parser.parse(server_time)
 
-
-class StationaryObstacle(Serializable):
+class StationaryObstacle(namedtuple('StationaryObstacle',
+                                    ['latitude', 'longitude',
+                                     'cylinder_height', 'cylinder_radius'])):
     """A stationary obstacle.
 
     This obstacle is a cylinder with a given location, height, and radius.
@@ -116,31 +124,25 @@ class StationaryObstacle(Serializable):
         cylinder_height: Height in feet
 
     Raises:
-        ValueError: Argument not convertable to float or out of range.
+        ValueError: Argument not valid.
     """
 
-    def __init__(self, latitude, longitude, cylinder_radius, cylinder_height):
-        super(StationaryObstacle, self).__init__(
-            ['latitude', 'longitude', 'cylinder_radius', 'cylinder_height'])
-
-        self.latitude = float(latitude)
-        self.longitude = float(longitude)
-        self.cylinder_radius = float(cylinder_radius)
-        self.cylinder_height = float(cylinder_height)
+    def __init__(self, *args, **kwargs):
+        check_type(self.latitude, float)
+        check_type(self.longitude, float)
+        check_type(self.cylinder_radius, float)
+        check_type(self.cylinder_height, float)
 
         check_latitude(self.latitude)
         check_longitude(self.longitude)
 
-        if self.cylinder_radius < 0:
-            raise ValueError('Cylinder radius (%f) must be non-negative' %
-                             self.cylinder_radius)
-
-        if self.cylinder_height < 0:
-            raise ValueError('Cylinder height (%f) must be non-negative' %
-                             self.cylinder_height)
+        check_bounds(self.cylinder_radius, 0, float("inf"))
+        check_bounds(self.cylinder_height, 0, float("inf"))
 
 
-class MovingObstacle(Serializable):
+class MovingObstacle(namedtuple(
+        'MovingObstacle',
+    ['latitude', 'longitude', 'altitude_msl', 'sphere_radius'])):
     """A moving obstacle.
 
     This obstacle is a sphere with a given location, altitude, and radius.
@@ -152,31 +154,33 @@ class MovingObstacle(Serializable):
         sphere_radius: Radius in feet
 
     Raises:
-        ValueError: Argument not convertable to float or out of range.
+        ValueError: Argument not valid.
     """
 
-    def __init__(self, latitude, longitude, altitude_msl, sphere_radius):
-        super(MovingObstacle, self).__init__(['latitude', 'longitude',
-                                              'altitude_msl', 'sphere_radius'])
-
-        self.latitude = float(latitude)
-        self.longitude = float(longitude)
-        self.altitude_msl = float(altitude_msl)
-        self.sphere_radius = float(sphere_radius)
+    def __init__(self, *args, **kwargs):
+        check_type(self.latitude, float)
+        check_type(self.longitude, float)
+        check_type(self.altitude_msl, float)
+        check_type(self.sphere_radius, float)
 
         check_latitude(self.latitude)
         check_longitude(self.longitude)
 
-        if self.sphere_radius < 0:
-            raise ValueError('Sphere radius (%f) must be non-negative' %
-                             self.sphere_radius)
+        check_bounds(self.sphere_radius, 0, float("inf"))
 
 
-class Target(Serializable):
+class Target(namedtuple(
+        'Target', ['id', 'user', 'type', 'latitude', 'longitude',
+                   'orientation', 'shape', 'background_color', 'alphanumeric',
+                   'alphanumeric_color', 'description'])):
     """A target.
 
     Attributes:
-        target_type: Target type, must be one of TargetType.
+        id: Optional. The ID of the target, assigned by interoperability
+            server. New targets shouldn't define this field.
+        user: Optional. The ID of the user who created the target, assigned by
+            interoperability server. New targets shouldn't define this field.
+        type: Target type, must be one of TargetType.
         latitude: Optional. Target latitude in decimal degrees. If provided,
             longitude must also be provided.
         longitude: Optional. Target longitude in decimal degrees. If provided,
@@ -193,33 +197,16 @@ class Target(Serializable):
         ValueError: Argument not valid.
     """
 
-    def __init__(self,
-                 target_type,
-                 latitude=None,
-                 longitude=None,
-                 orientation=None,
-                 shape=None,
-                 background_color=None,
-                 alphanumeric=None,
-                 alphanumeric_color=None,
-                 description=None):
-        super(Target, self).__init__(
-            ['target_type', 'latitude', 'longitude', 'orientation', 'shape',
-             'background_color', 'alphanumeric', 'alphanumeric_color',
-             'description'])
+    def __new__(cls, *args, **kwargs):
+        for field in cls._fields:
+            if field not in kwargs:
+                kwargs[field] = None
+        return super(Target, cls).__new__(cls, *args, **kwargs)
 
-        self.target_type = target_type
-        self.latitude = float(latitude)
-        self.longitude = float(longitude)
-        self.orientation = orientation
-        self.shape = shape
-        self.background_color = background_color
-        self.alphanumeric = alphanumeric
-        self.alphanumeric_color = alphanumeric_color
-        self.description = description
-
-        if not self.target_type:
-            raise ValueError('Provided target type is invalid.')
+    def __init__(self, *args, **kwargs):
+        check_type(self.type, str)
+        check_type(self.latitude, float)
+        check_type(self.longitude, float)
 
         check_latitude(self.latitude)
         check_longitude(self.longitude)
@@ -228,3 +215,6 @@ class Target(Serializable):
                 not re.match('^[0-9a-zA-Z]$', self.alphanumeric)):
             raise ValueError('Provided alphanumeric is not valid: %s' %
                              self.alphanumeric)
+
+    def _asdict(self):
+        return OrderedDict(zip(self._fields, self))

--- a/client/interop/types_test.py
+++ b/client/interop/types_test.py
@@ -9,30 +9,33 @@ class TestTelemetry(unittest.TestCase):
     def test_valid(self):
         """Test valid inputs"""
         # No exceptions
-        Telemetry(latitude=38, longitude=-76, altitude_msl=100, uas_heading=90)
+        Telemetry(latitude=38.0,
+                  longitude=-76.0,
+                  altitude_msl=100.0,
+                  uas_heading=90.0)
 
     def test_invalid(self):
         """Test invalid inputs"""
         # Bad latitude
         with self.assertRaises(ValueError):
-            Telemetry(latitude=120,
-                      longitude=-76,
-                      altitude_msl=100,
-                      uas_heading=90)
+            Telemetry(latitude=120.0,
+                      longitude=-76.0,
+                      altitude_msl=100.0,
+                      uas_heading=90.0)
 
         # Bad longitude
         with self.assertRaises(ValueError):
-            Telemetry(latitude=38,
-                      longitude=-200,
-                      altitude_msl=100,
-                      uas_heading=90)
+            Telemetry(latitude=38.0,
+                      longitude=-200.0,
+                      altitude_msl=100.0,
+                      uas_heading=90.0)
 
         # Bad heading
         with self.assertRaises(ValueError):
-            Telemetry(latitude=38,
-                      longitude=-76,
-                      altitude_msl=100,
-                      uas_heading=-90)
+            Telemetry(latitude=38.0,
+                      longitude=-76.0,
+                      altitude_msl=100.0,
+                      uas_heading=-90.0)
 
         # Bad type
         with self.assertRaises(ValueError):
@@ -41,21 +44,6 @@ class TestTelemetry(unittest.TestCase):
                       altitude_msl=100,
                       uas_heading=90)
 
-    def test_serialize(self):
-        """Test serialization"""
-        t = Telemetry(latitude=38,
-                      longitude=-76,
-                      altitude_msl=100,
-                      uas_heading=90)
-        s = t.serialize()
-
-        self.assertEqual(4, len(s))
-
-        self.assertEqual(38, s['latitude'])
-        self.assertEqual(-76, s['longitude'])
-        self.assertEqual(100, s['altitude_msl'])
-        self.assertEqual(90, s['uas_heading'])
-
 
 class TestStationaryObstacle(unittest.TestCase):
     """Test the StationaryObstacle object. There is very little to see here."""
@@ -63,62 +51,47 @@ class TestStationaryObstacle(unittest.TestCase):
     def test_valid(self):
         """Test valid inputs"""
         # No exceptions
-        StationaryObstacle(latitude=38,
-                           longitude=-76,
-                           cylinder_radius=100,
-                           cylinder_height=200)
+        StationaryObstacle(latitude=38.0,
+                           longitude=-76.0,
+                           cylinder_radius=100.0,
+                           cylinder_height=200.0)
 
     def test_invalid(self):
         """Test invalid inputs"""
         # Bad latitude
         with self.assertRaises(ValueError):
-            StationaryObstacle(latitude=120,
-                               longitude=-76,
-                               cylinder_radius=100,
-                               cylinder_height=200)
+            StationaryObstacle(latitude=120.0,
+                               longitude=-76.0,
+                               cylinder_radius=100.0,
+                               cylinder_height=200.0)
 
         # Bad longitude
         with self.assertRaises(ValueError):
-            StationaryObstacle(latitude=38,
-                               longitude=-200,
-                               cylinder_radius=100,
-                               cylinder_height=200)
+            StationaryObstacle(latitude=38.0,
+                               longitude=-200.0,
+                               cylinder_radius=100.0,
+                               cylinder_height=200.0)
 
         # Bad radius
         with self.assertRaises(ValueError):
-            StationaryObstacle(latitude=38,
-                               longitude=-76,
-                               cylinder_radius=-100,
-                               cylinder_height=200)
+            StationaryObstacle(latitude=38.0,
+                               longitude=-76.0,
+                               cylinder_radius=-100.0,
+                               cylinder_height=200.0)
 
         # Bad height
         with self.assertRaises(ValueError):
-            StationaryObstacle(latitude=38,
-                               longitude=-76,
-                               cylinder_radius=100,
-                               cylinder_height=-200)
+            StationaryObstacle(latitude=38.0,
+                               longitude=-76.0,
+                               cylinder_radius=100.0,
+                               cylinder_height=-200.0)
 
         # Bad type
         with self.assertRaises(ValueError):
-            StationaryObstacle(latitude=38,
+            StationaryObstacle(latitude=38.0,
                                longitude="Webster Field",
-                               cylinder_radius=100,
-                               cylinder_height=90)
-
-    def test_serialize(self):
-        """Test serialization"""
-        o = StationaryObstacle(latitude=38,
-                               longitude=-76,
-                               cylinder_radius=100,
-                               cylinder_height=200)
-        s = o.serialize()
-
-        self.assertEqual(4, len(s))
-
-        self.assertEqual(38, s['latitude'])
-        self.assertEqual(-76, s['longitude'])
-        self.assertEqual(100, s['cylinder_radius'])
-        self.assertEqual(200, s['cylinder_height'])
+                               cylinder_radius=100.0,
+                               cylinder_height=90.0)
 
 
 class TestMovingObstacle(unittest.TestCase):
@@ -127,55 +100,40 @@ class TestMovingObstacle(unittest.TestCase):
     def test_valid(self):
         """Test valid inputs"""
         # No exceptions
-        MovingObstacle(latitude=38,
-                       longitude=-76,
-                       altitude_msl=100,
-                       sphere_radius=200)
+        MovingObstacle(latitude=38.0,
+                       longitude=-76.0,
+                       altitude_msl=100.0,
+                       sphere_radius=200.0)
 
     def test_invalid(self):
         """Test invalid inputs"""
         # Bad latitude
         with self.assertRaises(ValueError):
-            MovingObstacle(latitude=120,
-                           longitude=-76,
-                           altitude_msl=100,
-                           sphere_radius=200)
+            MovingObstacle(latitude=120.0,
+                           longitude=-76.0,
+                           altitude_msl=100.0,
+                           sphere_radius=200.0)
 
         # Bad longitude
         with self.assertRaises(ValueError):
-            MovingObstacle(latitude=38,
-                           longitude=-200,
-                           altitude_msl=100,
-                           sphere_radius=200)
+            MovingObstacle(latitude=38.0,
+                           longitude=-200.0,
+                           altitude_msl=100.0,
+                           sphere_radius=200.0)
 
         # Bad radius
         with self.assertRaises(ValueError):
-            MovingObstacle(latitude=38,
-                           longitude=-76,
-                           altitude_msl=100,
-                           sphere_radius=-200)
+            MovingObstacle(latitude=38.0,
+                           longitude=-76.0,
+                           altitude_msl=100.0,
+                           sphere_radius=-200.0)
 
         # Bad type
         with self.assertRaises(ValueError):
-            MovingObstacle(latitude=38,
+            MovingObstacle(latitude=38.0,
                            longitude="Webster Field",
-                           altitude_msl=100,
-                           sphere_radius=90)
-
-    def test_serialize(self):
-        """Test serialization"""
-        o = MovingObstacle(latitude=38,
-                           longitude=-76,
-                           altitude_msl=100,
-                           sphere_radius=200)
-        s = o.serialize()
-
-        self.assertEqual(4, len(s))
-
-        self.assertEqual(38, s['latitude'])
-        self.assertEqual(-76, s['longitude'])
-        self.assertEqual(100, s['altitude_msl'])
-        self.assertEqual(200, s['sphere_radius'])
+                           altitude_msl=100.0,
+                           sphere_radius=90.0)
 
 
 class TestTarget(unittest.TestCase):
@@ -183,55 +141,55 @@ class TestTarget(unittest.TestCase):
 
     def test_valid(self):
         """Test valid inputs."""
-        Target(target_type='standard',
-               latitude=10,
-               longitude=-10,
+        Target(type='standard',
+               latitude=10.0,
+               longitude=-10.0,
                orientation='n',
                shape='circle',
                background_color='white',
                alphanumeric='a',
                alphanumeric_color='black')
 
-        Target(target_type='qrc',
-               latitude=10,
-               longitude=-10,
+        Target(type='qrc',
+               latitude=10.0,
+               longitude=-10.0,
                description='http://test.com')
 
-        Target(target_type='off_axis',
-               latitude=10,
-               longitude=-10,
+        Target(type='off_axis',
+               latitude=10.0,
+               longitude=-10.0,
                orientation='n',
                shape='circle',
                background_color='white',
                alphanumeric='a',
                alphanumeric_color='black')
 
-        Target(target_type='emergent',
-               latitude=10,
-               longitude=-10,
+        Target(type='emergent',
+               latitude=10.0,
+               longitude=-10.0,
                description='Fireman putting out a fire.')
 
     def test_invalid(self):
         """Test invalid inputs."""
         with self.assertRaises(ValueError):
-            Target(target_type=None, latitude=10, longitude=10)
+            Target(type=None, latitude=10.0, longitude=10.0)
 
         with self.assertRaises(ValueError):
-            Target(target_type='qrc',
-                   latitude=10000,
-                   longitude=-10,
+            Target(type='qrc',
+                   latitude=10000.0,
+                   longitude=-10.0,
                    description='http://test.com')
 
         with self.assertRaises(ValueError):
-            Target(target_type='qrc',
-                   latitude=10,
-                   longitude=-10000,
+            Target(type='qrc',
+                   latitude=10.0,
+                   longitude=-10000.0,
                    description='http://test.com')
 
         with self.assertRaises(ValueError):
-            Target(target_type='standard',
-                   latitude=10,
-                   longitude=-10,
+            Target(type='standard',
+                   latitude=10.0,
+                   longitude=-10.0,
                    orientation='n',
                    shape='circle',
                    background_color='white',
@@ -239,33 +197,11 @@ class TestTarget(unittest.TestCase):
                    alphanumeric_color='black')
 
         with self.assertRaises(ValueError):
-            Target(target_type='standard',
-                   latitude=10,
-                   longitude=-10,
+            Target(type='standard',
+                   latitude=10.0,
+                   longitude=-10.0,
                    orientation='n',
                    shape='circle',
                    background_color='white',
                    alphanumeric='.',
                    alphanumeric_color='black')
-
-    def test_serialize(self):
-        """Test serialization."""
-        o = Target(target_type='standard',
-                   latitude=10,
-                   longitude=-10,
-                   orientation='n',
-                   shape='circle',
-                   background_color='white',
-                   alphanumeric='a',
-                   alphanumeric_color='black')
-        s = o.serialize()
-
-        self.assertEqual(9, len(s))
-        self.assertEqual('standard', s['target_type'])
-        self.assertEqual(10, s['latitude'])
-        self.assertEqual(-10, s['longitude'])
-        self.assertEqual('n', s['orientation'])
-        self.assertEqual('circle', s['shape'])
-        self.assertEqual('white', s['background_color'])
-        self.assertEqual('a', s['alphanumeric'])
-        self.assertEqual('black', s['alphanumeric_color'])


### PR DESCRIPTION
For #50 

Our custom serialization/deserialization can be handled by `collections.namedtuple`. This PR refactors to use that instead, which will be useful going forward (easier to add new types and serialize/deserialize in multiple places). Note this makes client types immutable.

Add the id,user fields to Target which were missing in last PR.