### PR TITLE
Heading and orientation reference true north

### DIFF
--- a/client/interop/types.py
+++ b/client/interop/types.py
@@ -60,7 +60,7 @@ class Telemetry(Serializable):
         latitude: Latitude in decimal degrees.
         longitude: Longitude in decimal degrees.
         altitude_msl: Altitude MSL in feet.
-        uas_heading: Aircraft heading in degrees (0-360).
+        uas_heading: Aircraft heading (true north) in degrees (0-360).
 
     Raises:
         ValueError: Argument not convertable to float or out of range.

--- a/docs/spec.rst
+++ b/docs/spec.rst
@@ -361,8 +361,8 @@ UAS Telemetry
    :form altitude\_msl: The height above mean sea level (MSL) of the aircraft
                         in feet as a floating point value.
 
-   :form uas\_heading: The heading of the aircraft as a floating point degree
-                       value. Valid values are: 0 <= uas\_heading <= 360.
+   :form uas\_heading: The (true north) heading of the aircraft as a floating point
+                       degree value. Valid values are: 0 <= uas\_heading <= 360.
 
    :status 200: The team made a valid request. The information will be stored
                 on the competition server to evaluate various competition
@@ -1033,6 +1033,7 @@ Targets
 .. py:data:: Orientations
 
    These are the valid orientations that may be specified for a target.
+   They reference true north, not magnetic north.
 
    * ``N`` - North
    * ``NE`` - Northeast

--- a/server/auvsi_suas/models/uas_telemetry.py
+++ b/server/auvsi_suas/models/uas_telemetry.py
@@ -15,7 +15,7 @@ class UasTelemetry(AccessLog):
     """UAS telemetry reported by teams."""
     # The position of the UAS
     uas_position = models.ForeignKey(AerialPosition)
-    # The heading of the UAS in degrees (e.g. 0=north, 90=east)
+    # The (true north) heading of the UAS in degrees
     uas_heading = models.FloatField()
 
     def __unicode__(self):

--- a/server/auvsi_suas/views/telemetry.py
+++ b/server/auvsi_suas/views/telemetry.py
@@ -26,7 +26,7 @@ class Telemetry(View):
         latitude: A latitude in decimal degrees.
         longitude: A logitude in decimal degrees.
         altitude_msl: An MSL altitude in decimal feet.
-        uas_heading: The UAS heading in decimal degrees. (0=north, 90=east)
+        uas_heading: The UAS (true north) heading in decimal degrees.
         """
         try:
             # Get the parameters


### PR DESCRIPTION
Explicitly state that the UAS telemetry heading and target orientation
are both based on true north, not magnetic north.

Closes #29