### PR TITLE
Add 'autonomous' Target field

### DIFF
--- a/client/interop/types.py
+++ b/client/interop/types.py
@@ -158,6 +158,8 @@ class Target(ClientBaseType):
         alphanumeric_color: Optional. Target alphanumeric color.
         description: Optional. Free-form description of the target, used for
             certain target types.
+        autonomous: Optional; defaults to False. Indicates that this is an
+            ADLC target.
 
     Raises:
         ValueError: Argument not valid.
@@ -165,7 +167,7 @@ class Target(ClientBaseType):
 
     attrs = ['id', 'user', 'type', 'latitude', 'longitude', 'orientation',
              'shape', 'background_color', 'alphanumeric', 'alphanumeric_color',
-             'description']
+             'description', 'autonomous']
 
     def __init__(self,
                  id=None,
@@ -178,7 +180,8 @@ class Target(ClientBaseType):
                  background_color=None,
                  alphanumeric=None,
                  alphanumeric_color=None,
-                 description=None):
+                 description=None,
+                 autonomous=False):
         self.id = id
         self.user = user
         self.type = type
@@ -190,3 +193,4 @@ class Target(ClientBaseType):
         self.alphanumeric = alphanumeric
         self.alphanumeric_color = alphanumeric_color
         self.description = description
+        self.autonomous = autonomous

--- a/client/interop/types_test.py
+++ b/client/interop/types_test.py
@@ -236,6 +236,8 @@ class TestTarget(unittest.TestCase):
                longitude=-10,
                description='Fireman putting out a fire.')
 
+        Target(type='standard', latitude=10, longitude=-10, autonomous=True)
+
     def test_invalid(self):
         """Test invalid inputs."""
         # Bad latitude.
@@ -262,10 +264,11 @@ class TestTarget(unittest.TestCase):
                    shape='circle',
                    background_color='white',
                    alphanumeric='a',
-                   alphanumeric_color='black')
+                   alphanumeric_color='black',
+                   autonomous=True)
         s = o.serialize()
 
-        self.assertEqual(10, len(s))
+        self.assertEqual(11, len(s))
         self.assertEqual(1, s['id'])
         self.assertEqual(2, s['user'])
         self.assertEqual('standard', s['type'])
@@ -276,6 +279,7 @@ class TestTarget(unittest.TestCase):
         self.assertEqual('white', s['background_color'])
         self.assertEqual('a', s['alphanumeric'])
         self.assertEqual('black', s['alphanumeric_color'])
+        self.assertEqual(True, s['autonomous'])
 
     def test_deserialize(self):
         """Test deserialization."""
@@ -287,7 +291,8 @@ class TestTarget(unittest.TestCase):
             'shape': 'circle',
             'background_color': 'white',
             'alphanumeric': 'a',
-            'alphanumeric_color': 'black'
+            'alphanumeric_color': 'black',
+            'autonomous': True,
         })
 
         self.assertEqual('standard', o.type)
@@ -298,6 +303,7 @@ class TestTarget(unittest.TestCase):
         self.assertEqual('white', o.background_color)
         self.assertEqual('a', o.alphanumeric)
         self.assertEqual('black', o.alphanumeric_color)
+        self.assertEqual(True, o.autonomous)
 
         o = Target.deserialize({'type': 'qrc'})
 

--- a/docs/spec.rst
+++ b/docs/spec.rst
@@ -438,6 +438,7 @@ Targets
           "alphanumeric": "C",
           "alphanumeric_color": "black",
           "description": null,
+          "autonomous": false,
       }
 
    The response format is the same as :http:get:`/api/targets/(int:id)` and
@@ -479,6 +480,15 @@ Targets
    :<json string description: (optional) Free-form description of target. This
                               should be used for describing certain target
                               types (see :py:data:`TargetTypes`).
+
+   :<json boolean autonomous: (optional, default ``false``) This target was
+                              detected, localized, and characterized by the
+                              team's ADLC system, per section 7.3 of the
+                              rules. Note that if this field is set, then
+                              detection, localization, and characterization
+                              must be autonomous, with no human input. Per
+                              section 7.3 of the rules, no more than six
+                              targets should be marked autonomous.
 
    :resheader Content-Type: The response is ``application/json`` on success.
 
@@ -540,6 +550,7 @@ Targets
               "alphanumeric": "C",
               "alphanumeric_color": "black",
               "description": null,
+              "autonomous": false,
           },
           {
               "id": 2,
@@ -553,6 +564,7 @@ Targets
               "alphanumeric": null,
               "alphanumeric_color": null,
               "description": "http://auvsi-seafarer.org",
+              "autonomous": false,
           }
       ]
 
@@ -614,6 +626,7 @@ Targets
           "alphanumeric": "C",
           "alphanumeric_color": "black",
           "description": null,
+          "autonomous": false,
       }
 
    :reqheader Cookie: The session cookie obtained from :http:post:`/api/login`
@@ -656,6 +669,8 @@ Targets
 
    :>json string description: Target description; ``null`` if no description
                               specified yet.
+
+   :>json boolean autonomous: Target is an ADLC target.
 
    :status 200: Success. Response contains target details.
 
@@ -716,6 +731,7 @@ Targets
           "alphanumeric": "O",
           "alphanumeric_color": "black",
           "description": null,
+          "autonomous": false,
       }
 
    This endpoint accepts all fields described in :http:post:`/api/targets` in
@@ -936,9 +952,12 @@ Targets
    This endpoint is used to delete the image associated with a target. A deleted
    image will not be used in scoring.
 
-   Note: You do not need to delete the target image before uploading a new
-   image. A call to :http:post:`/api/targets/(int:id)/image` or
-   :http:put:`/api/targets/(int:id)/image` will overwrite the existing image.
+   .. note::
+
+      You do not need to delete the target image before uploading a new image.
+      A call to :http:post:`/api/targets/(int:id)/image` or
+      :http:put:`/api/targets/(int:id)/image` will overwrite the existing
+      image.
 
    **Example request**:
 
@@ -980,8 +999,6 @@ Targets
 
    These are the valid types of targets which may be specified.
 
-   .. TODO(prattmic): Update with 2016 sections.
-
    * ``standard`` - Standard targets are described in section 7.2.7 of the rules.
 
    Describe the target characteristics with these fields (see
@@ -994,6 +1011,7 @@ Targets
       * ``background_color``
       * ``alphanumeric``
       * ``alphanumeric_color``
+      * ``autonomous``
 
    * ``qrc`` - Quick Response Code (QRC) targets are described in section
      7.2.8 of the rules.

--- a/server/auvsi_suas/migrations/0014_add_autonomous_targets.py
+++ b/server/auvsi_suas/migrations/0014_add_autonomous_targets.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [('auvsi_suas', '0013_remove_ir_as_target_type'), ]
+
+    operations = [
+        migrations.AddField(model_name='target',
+                            name='autonomous',
+                            field=models.BooleanField(default=False), ),
+    ]

--- a/server/auvsi_suas/models/target.py
+++ b/server/auvsi_suas/models/target.py
@@ -155,6 +155,9 @@ class Target(models.Model):
     # Free-form target description.
     description = models.TextField(default='', blank=True)
 
+    # Target is an ADLC submission.
+    autonomous = models.BooleanField(default=False)
+
     # Uploaded target image thumbnail.
     thumbnail = models.ImageField(upload_to='targets', blank=True)
 
@@ -171,6 +174,7 @@ class Target(models.Model):
                        "alphanumeric='{alphanumeric}', "
                        "alphanumeric_color={alphanumeric_color}, "
                        "description='{description}', "
+                       "autonomous='{autonomous}', "
                        "thumbnail='{thumbnail}')".format(
                            name=self.__class__.__name__,
                            thumbnail=self.thumbnail,
@@ -224,4 +228,5 @@ class Target(models.Model):
             'alphanumeric': alphanumeric,
             'alphanumeric_color': alphanumeric_color,
             'description': description,
+            'autonomous': self.autonomous,
         }

--- a/server/auvsi_suas/models/target_test.py
+++ b/server/auvsi_suas/models/target_test.py
@@ -91,7 +91,8 @@ class TestTarget(TestCase):
                    background_color=Color.white,
                    alphanumeric='ABC',
                    alphanumeric_color=Color.black,
-                   description='Test target')
+                   description='Test target',
+                   autonomous=True)
         t.save()
 
         d = t.json()
@@ -107,6 +108,7 @@ class TestTarget(TestCase):
         self.assertEqual('ABC', d['alphanumeric'])
         self.assertEqual('black', d['alphanumeric_color'])
         self.assertEqual('Test target', d['description'])
+        self.assertEqual(True, d['autonomous'])
 
     def test_minimal_json(self):
         """Test target JSON with minimal data."""
@@ -126,3 +128,4 @@ class TestTarget(TestCase):
         self.assertEqual(None, d['alphanumeric'])
         self.assertEqual(None, d['alphanumeric_color'])
         self.assertEqual(None, d['description'])
+        self.assertEqual(False, d['autonomous'])

--- a/server/auvsi_suas/views/targets.py
+++ b/server/auvsi_suas/views/targets.py
@@ -103,6 +103,10 @@ def normalize_data(data):
             raise ValueError('Unknown color "%s"; known colors %r' %
                              (data['alphanumeric_color'], Color.names()))
 
+    if 'autonomous' in data:
+        if data['autonomous'] is not True and data['autonomous'] is not False:
+            raise ValueError('"autonmous" must be true or false')
+
     return data
 
 
@@ -164,7 +168,8 @@ class Targets(View):
                    background_color=data.get('background_color'),
                    alphanumeric=data.get('alphanumeric', ''),
                    alphanumeric_color=data.get('alphanumeric_color'),
-                   description=data.get('description', ''))
+                   description=data.get('description', ''),
+                   autonomous=data.get('autonomous', False))
         t.save()
 
         return JsonResponse(t.json(), status=201)
@@ -242,6 +247,8 @@ class TargetsId(View):
             target.alphanumeric_color = data['alphanumeric_color']
         if 'description' in data:
             target.description = data['description']
+        if 'autonomous' in data:
+            target.autonomous = data['autonomous']
 
         # Location is special because it is in a GpsPosition model
 


### PR DESCRIPTION
This field is used distinguish targets that are submitted as ADLC
targets. The rules are strict about only grading the first six
submissions, so these targets are locked down and may not be changed or
deleted once submitted.

References #30