### PR TITLE
Add explicit sphinx_rtd_theme dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx>=1.3
 sphinxcontrib-httpdomain>=1.3
+sphinx_rtd_theme


### PR DESCRIPTION
Sphinx 1.4 no longer includes it by default.