### PR TITLE
Drop interop client dependency from docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,6 +107,15 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+# -- Options for autodoc --------------------------------------------------
+
+# Add the client to the path. The client is not installed in this virtualenv.
+# Instead we will mock out its dependencies and import it directly.
+sys.path.insert(0, os.path.abspath('../client/'))
+
+# Mock out client dependencies.
+autodoc_mock_imports = ['concurrent.futures', 'dateutil.parser', 'requests']
+
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,3 @@
 sphinx>=1.3
 sphinxcontrib-httpdomain>=1.3
 sphinx_rtd_theme
-
-# interop module and its requirements
-# Note: these are relative to the `pip install` invocation, not this file,
-# so pip must be invoked from this directory.
--r ../client/requirements.txt
-file:../client#egg=interop

--- a/setup/puppet_files/auvsi_suas/manifests/docs_setup.pp
+++ b/setup/puppet_files/auvsi_suas/manifests/docs_setup.pp
@@ -9,6 +9,5 @@ class auvsi_suas::docs_setup {
         ensure => 'present',
         version => 'system',
         requirements => '/interop/docs/requirements.txt',
-        cwd => '/interop/docs/',
     }
 }


### PR DESCRIPTION
ReadTheDocs runs `pip install` from the root of the repo and doesn't
seem to be configurable, so it can't properly install the interop
client.

Instead of adding a dependency, teach Sphinx to mock the client
dependencies and import the module directly.