### PR TITLE
Make puppet exit with a non-zero code on failure

### DIFF
--- a/setup/puppet_files/auvsi_suas/manifests/client_install.pp
+++ b/setup/puppet_files/auvsi_suas/manifests/client_install.pp
@@ -28,7 +28,7 @@ class auvsi_suas::client_install {
         pkgname => '/interop/client',
         ensure => 'latest',
         virtualenv => '/interop/client/venv2',
-        install_args => ['-e'], # develop mode
+        install_args => '-e', # develop mode
         require => Python::Virtualenv['/interop/client/venv2'],
     }
 
@@ -37,7 +37,7 @@ class auvsi_suas::client_install {
         pkgname => '/interop/client',
         ensure => 'latest',
         virtualenv => '/interop/client/venv3',
-        install_args => ['-e'], # develop mode
+        install_args => '-e', # develop mode
         require => Python::Virtualenv['/interop/client/venv3'],
     }
 

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -76,6 +76,16 @@ ensure_puppet_module stankevich-python
 
 # Launch the Puppet process. Prepares machine.
 log "Executing Puppet setup..."
+set +e
 sudo ${PUPPET} apply \
+    --detailed-exitcodes \
     --modulepath=${SETUP}/puppet_files:/etc/puppetlabs/code/environments/production/modules \
     ${SETUP}/puppet_files/auvsi_suas.pp
+
+# Exit codes 0 and 2 indicate success, so rewrite code 2 as 0.
+# https://docs.puppet.com/puppet/latest/reference/man/agent.html#OPTIONS
+code=$?
+if [[ ${code} == 2 ]]; then
+    code=0
+fi
+exit ${code}


### PR DESCRIPTION
For some absurd reason, puppet exits with a zero exit code, even if the
configuration fails to apply. --detailed-exitcodes is needed to make it
exit non-zero:
https://docs.puppet.com/puppet/latest/reference/man/agent.html#OPTIONS

Now Travis builds should fail early when the configuration fails to
apply.