### PR TITLE
Allow admins ability to read targets+images.

### DIFF
--- a/server/auvsi_suas/views/targets.py
+++ b/server/auvsi_suas/views/targets.py
@@ -193,10 +193,11 @@ def find_target(request, pk):
     """
     target = Target.objects.get(pk=pk)
 
-    # We only let users get their own targets.
-    if target.user != request.user:
+    # We only let users get their own targets, unless a superuser.
+    if target.user == request.user or request.user.is_superuser:
+        return target
+    else:
         raise ValueError("Accessing target %d not allowed" % pk)
-    return target
 
 
 class TargetsId(View):


### PR DESCRIPTION
Turns out for review we need an interface for requesting imagery. Rather than duplicate it, give admins access.