### PR TITLE
Add a frontend for target review.

### DIFF
--- a/server/auvsi_suas/static/auvsi_suas/app.css
+++ b/server/auvsi_suas/static/auvsi_suas/app.css
@@ -5,3 +5,7 @@
 .row {
     max-width: 100%;
 }
+
+hr {
+    margin: 0;
+}

--- a/server/auvsi_suas/static/auvsi_suas/app.js
+++ b/server/auvsi_suas/static/auvsi_suas/app.js
@@ -26,6 +26,11 @@ auvsiSuasApp.config(['$routeProvider', function($routeProvider) {
             controller: 'MissionDashboardCtrl',
             controllerAs: 'missionDashboardCtrl'
         }).
+        when('/mission/:missionId/targets', {
+            templateUrl: '/static/auvsi_suas/pages/target-review/target-review.html',
+            controller: 'TargetReviewCtrl',
+            controllerAs: 'targetReviewCtrl'
+        }).
         otherwise({
             redirectTo: '/'
         });

--- a/server/auvsi_suas/static/auvsi_suas/auvsi_suas.conf.karma.js
+++ b/server/auvsi_suas/static/auvsi_suas/auvsi_suas.conf.karma.js
@@ -36,6 +36,7 @@ module.exports = function(config) {
       'components/team-status/team-status-controller.js',
       'pages/mission-dashboard/mission-dashboard-controller.js',
       'pages/mission-list/mission-list-controller.js',
+      'pages/target-review/target-review-controller.js',
       // Test files.
       'components/settings/settings-service_test.js',
       'components/navigation/navigation_test.js',
@@ -45,6 +46,7 @@ module.exports = function(config) {
       'components/team-status/team-status-controller_test.js',
       'pages/mission-dashboard/mission-dashboard-controller_test.js',
       'pages/mission-list/mission-list-controller_test.js',
+      'pages/target-review/target-review-controller_test.js',
     ],
 
 

--- a/server/auvsi_suas/static/auvsi_suas/components/navigation/navigation.js
+++ b/server/auvsi_suas/static/auvsi_suas/components/navigation/navigation.js
@@ -27,11 +27,6 @@ NavigationCtrl = function($routeParams) {
             target: "_blank"
         },
         {
-            text: "Evaluate Teams (CSV)",
-            url: "/auvsi_admin/evaluate_teams.csv",
-            target: "_blank"
-        },
-        {
             text: "Export Data (KML)",
             url: "/auvsi_admin/export_data.kml",
             target: "_blank"
@@ -85,6 +80,16 @@ NavigationCtrl.prototype.shouldShowMissionLinks = function() {
  */
 NavigationCtrl.prototype.updateMissionLinks_ = function() {
     this.missionLinks_ = [
+        {
+            text: "Dashboard",
+            url: "/#/mission/" + this.mission_,
+            target: "_self",
+        },
+        {
+            text: "Review Targets",
+            url: "/#/mission/" + this.mission_ + "/targets",
+            target: "_self"
+        },
         {
             text: "Evaluate Teams (CSV)",
             url: "/auvsi_admin/evaluate_teams.csv?mission=" + this.mission_,

--- a/server/auvsi_suas/static/auvsi_suas/pages/mission-dashboard/mission-dashboard.html
+++ b/server/auvsi_suas/static/auvsi_suas/pages/mission-dashboard/mission-dashboard.html
@@ -5,10 +5,34 @@
       <h4>Dashboard</h4>
       <h5><a data-reveal-id="dashboardHelpModal">Help</a></h5>
       <div id="dashboardHelpModal" class="reveal-modal" data-reveal>
-        <h5>Left Status Pane</h5>
-        <p>Contains status information about the teams which are interacting with the system. A team appears in the pane when they are either in-air or active. A team is considered in-air if the last TakeoffOrLandingEvent a judge logged indicated UAS in air. A team is considered active if they recently performed an interoperability interaction.</p>
-        <h5>Right 3D Display</h5>
-        <p>The 3D display pulls data from the backend at a regular rate and displays it. The display is initially centered at the MissionConfig's home position, and is indicated by a green sphere. The white spheres indicate MissionConfig mission elements like the SRIC position. The blue spheres show waypoints, and the light blue spheres show the search grid. The red sphere and red cylinders indicate obstacle positions. Finally, the yellow spheres show UAS positions.</p>
+        <h4>Mission Dashboard</h4>
+        <p><strong>Left Status Pane.</strong> Contains status information about
+        the teams which are interacting with the system. A team appears in the
+        pane when they are either in-air (TakeoffOrLandingEvent) or active
+        (recent interop requests).</p>
+        <p><strong>Right 3D Display.</strong> The display pulls data (mission
+        config, telemetry, obstacles) from the backend at a regular rate and
+        displays it. The display is initially centered at the MissionConfig's
+        home position (green sphere).  Additional elements are mission elements
+        (white spheres, e.g. SRIC), waypoints (blue spheres), search grid
+        (light blue spheres), obstacles (red spheres and cylinders), and UAS
+        positions (yellow spheres).</p>
+        <h4>System Menu</h4>
+        <p><strong>Live View (KML).</strong> Downloads a KML file to view live
+        mission and telemetry data in Google Earth.</p>
+        <p><strong>Export Data (KML).</strong> Exports mission and telemetry
+        data as a KML file which can be viewed in Google Earth.</p>
+        <p><strong>Edit Data.</strong> Opens the Django admin page for editing
+        raw data, and currently is the primary mechanism for configuring the
+        server.</p>
+        <p><strong>Clear Cache.</strong> Forces the caches to be cleared, so
+        updated are viewed instantly.</p>
+        <h4>Mission Menu</h4>
+        <p><strong>Mission Dashboard.</strong> Opens this page.
+        <p><strong>Review Targets.</strong> Interface to review target imagery,
+        review of which must be done prior to team evaluation.
+        <p><strong>Evaluate Teams (CSV).</strong> Evaluates the teams on the
+        mission and saves a CSV file.</p>
       </div>
     </div>
 

--- a/server/auvsi_suas/static/auvsi_suas/pages/target-review/target-review-controller.js
+++ b/server/auvsi_suas/static/auvsi_suas/pages/target-review/target-review-controller.js
@@ -1,0 +1,182 @@
+/**
+ * Controller for the Target Review page.
+ */
+
+
+
+/**
+ * Controller for the Target Review page.
+ * @param {!angular.Window} $window The window service.
+ * @param {!Object} Backend The backend service.
+ * @final
+ * @constructor
+ * @struct
+ * @ngInject
+ */
+TargetReviewCtrl = function($window, Backend) {
+    /**
+     * @private @const {!angular.Window} The window service.
+     */
+    this.window_ = $window;
+
+    /**
+     * @private @const {!Object} The backend service.
+     */
+    this.backend_ = Backend;
+
+    /**
+     * @private {?Object} The target under review.
+     */
+    this.target_ = null;
+
+    /**
+     * @private {?Array<Object>} The target review details.
+     */
+    this.targetDetails_ = null;
+};
+
+
+/**
+ * Gets the targets for review.
+ * @return {?Array<Object>} The targets.
+ * @export
+ */
+TargetReviewCtrl.prototype.getReviewTargets = function() {
+    return this.backend_.reviewTargets;
+};
+
+
+/**
+ * Gets the class for the target.
+ * @param {!Object} target The target.
+ * @return {string} The class.
+ * @export
+ */
+TargetReviewCtrl.prototype.getTargetButtonClass = function(target) {
+    var thumbnailClass;
+    if (target.thumbnail_approved == null) {
+        thumbnailClass = 'button';
+    } else if (target.thumbnail_approved) {
+        thumbnailClass = 'success button';
+    } else {
+        thumbnailClass = 'alert button';
+    }
+
+    if (this.target_ && target.id == this.target_.id) {
+        return thumbnailClass + ' disabled';
+    } else {
+        return thumbnailClass;
+    }
+};
+
+
+/**
+ * Sets the target under review.
+ * @param {!Object} target The target to review.
+ * @export
+ */
+TargetReviewCtrl.prototype.setReviewTarget = function(target) {
+    this.target_ = target;
+
+    if (target == null) {
+        this.targetDetails_ = null;
+        return;
+    }
+
+    this.targetDetails_ = [
+        {'key': 'ID',
+         'value': target.id},
+        {'key': 'Type',
+         'value': target.type},
+    ];
+    if (target.type == 'standard' || target.type == 'off_axis') {
+        this.targetDetails_ = this.targetDetails_.concat([
+            {'key': 'Alpha Color',
+             'value': target.alphanumeric_color},
+            {'key': 'Alpha',
+             'value': target.alphanumeric},
+            {'key': 'Shape Color',
+             'value': target.background_color},
+            {'key': 'Shape',
+             'value': target.shape}
+        ]);
+    } else {
+        this.targetDetails_ = this.targetDetails_.concat([
+            {'key': 'Desc',
+             'value': target.description}
+        ]);
+    }
+};
+
+
+/**
+ * @return {?Object} The target under review.
+ */
+TargetReviewCtrl.prototype.getReviewTarget = function() {
+    return this.target_;
+};
+
+/**
+ * @return {?Object} The target details.
+ */
+TargetReviewCtrl.prototype.getReviewTargetDetails = function() {
+    return this.targetDetails_;
+};
+
+
+/**
+ * Sets the review status for the target under review. Advances to
+ * the next target for review.
+ * @param {bool} approved The review status to set.
+ */
+TargetReviewCtrl.prototype.setReview = function(approved) {
+    this.target_.thumbnail_approved = approved;
+    this.target_.$update().then(
+            angular.bind(this, this.nextTarget_));
+};
+
+
+/**
+ * Advances to the next target.
+ */
+TargetReviewCtrl.prototype.nextTarget_ = function() {
+    var targets = this.getReviewTargets();
+
+    for (var i = 0; i < targets.length-1; i++) {
+        if (targets[i].id == this.target_.id) {
+            this.setReviewTarget(targets[i+1]);
+            return;
+        }
+    }
+
+    this.setReviewTarget(targets[targets.length-1]);
+};
+
+
+/**
+ * @return {string} The class info for the target image review.
+ */
+TargetReviewCtrl.prototype.getTargetImgStyle = function() {
+    if (!!this.target_) {
+        return 'background-image: url(/api/targets/' + this.target_.id +
+                '/image); height: ' + this.getTargetImgHeight() + 'px;';
+    } else {
+        return '';
+    }
+}
+
+
+/**
+ * @return {number} The height of the target image display.
+ */
+TargetReviewCtrl.prototype.getTargetImgHeight = function() {
+    return this.window_.innerHeight - 95;
+};
+
+
+// Register controller with app.
+angular.module('auvsiSuasApp').controller('TargetReviewCtrl', [
+    '$window',
+    'Backend',
+    TargetReviewCtrl
+]);

--- a/server/auvsi_suas/static/auvsi_suas/pages/target-review/target-review-controller_test.js
+++ b/server/auvsi_suas/static/auvsi_suas/pages/target-review/target-review-controller_test.js
@@ -1,0 +1,59 @@
+/**
+ * Tests for the TargetReviewCtrl controller.
+ */
+
+
+describe("TargetReviewCtrl controller", function() {
+    var backend;
+    var reviewTargets, updateFunc;
+    var targetReviewCtrl;
+
+    beforeEach(module('auvsiSuasApp'));
+
+    beforeEach(inject(function($controller) {
+        updateFunc = function() {
+            this.updated = true;
+            return {then: function(func) {func();}};
+        };
+        reviewTargets = [
+             {id: 1, thumbnail_approved: null, $update: updateFunc},
+             {id: 2, thumbnail_approved: true, $update: updateFunc},
+             {id: 3, thumbnail_approved: false, $update: updateFunc}];
+        backend = {
+            missions: [{id: 1}, {id: 2}],
+            obstacles: [],
+            reviewTargets: reviewTargets,
+        };
+
+        targetReviewCtrl = $controller('TargetReviewCtrl',
+                                       {Backend: backend});
+    }));
+
+    it("Should get review targets", function() {
+        expect(targetReviewCtrl.getReviewTargets()).toEqual(reviewTargets);
+    });
+
+    it("Should get target button class", function() {
+        targetReviewCtrl.setReviewTarget(reviewTargets[0]);
+        expect(targetReviewCtrl.getTargetButtonClass(reviewTargets[0]))
+                .toEqual('button disabled');
+        expect(targetReviewCtrl.getTargetButtonClass(reviewTargets[1]))
+                .toEqual('success button');
+        expect(targetReviewCtrl.getTargetButtonClass(reviewTargets[2]))
+                .toEqual('alert button');
+    });
+
+    it("Should get review target", function() {
+        targetReviewCtrl.setReviewTarget(reviewTargets[0]);
+        expect(targetReviewCtrl.getReviewTarget()).toEqual(reviewTargets[0]);
+    });
+
+    it("Should update the review", function() {
+        targetReviewCtrl.setReviewTarget(reviewTargets[0]);
+        targetReviewCtrl.setReview(true);
+        expect(reviewTargets[0].thumbnail_approved).toBe(true);
+        expect(reviewTargets[0].updated).toBe(true);
+        expect(targetReviewCtrl.getReviewTarget().id)
+                .toEqual(reviewTargets[1].id);
+    });
+});

--- a/server/auvsi_suas/static/auvsi_suas/pages/target-review/target-review.css
+++ b/server/auvsi_suas/static/auvsi_suas/pages/target-review/target-review.css
@@ -1,0 +1,43 @@
+/**
+ * Styles for the Target Review page.
+ */
+
+#target-list {
+    padding: 0 20px 0 20px;
+}
+
+.target-list-item {
+    margin: 0;
+    width: 100%;
+}
+
+#target-img-holder {
+    padding: 20px;
+}
+
+#target-img-holder div {
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+}
+
+#target-detail {
+    margin-top: 20px;
+    padding: 20px;
+}
+
+#target-detail div {
+    padding: 10px;
+}
+
+#target-detail div h4 {
+    text-decoration: underline;
+}
+
+#target-approve-deny {
+    text-align: center;
+}
+
+#target-approve-deny button {
+    display: inline-block;
+}

--- a/server/auvsi_suas/static/auvsi_suas/pages/target-review/target-review.html
+++ b/server/auvsi_suas/static/auvsi_suas/pages/target-review/target-review.html
@@ -1,0 +1,38 @@
+<div class="row">
+  <div class="small-2 columns">
+    <div class="row text-center text-middle">
+      <h4>Target Review</h4>
+    </div>
+
+    <hr></hr>
+
+    <div class="row text-center text-middle">
+        <div id="target-list" class="button-group stacked">
+            <button type="button"
+                class="target-list-item {{targetReviewCtrl.getTargetButtonClass(target)}}"
+                ng-repeat="target in targetReviewCtrl.getReviewTargets()"
+                ng-click="targetReviewCtrl.setReviewTarget(target)">
+                {{target.id}}
+            </button>
+        </div>
+    </div>
+  </div>
+
+  <div id="target-detail" class="small-3 columns panel"
+       ng-show="targetReviewCtrl.getReviewTarget()">
+    <div id="target-approve-deny">
+        <button type="button" class="success button" ng-click="targetReviewCtrl.setReview(true)">Approve</button>
+        <button type="button" class="alert button" ng-click="targetReviewCtrl.setReview(false)">Deny</button>
+    </div>
+    <div ng-repeat="detail in targetReviewCtrl.getReviewTargetDetails()" >
+        <h4>{{detail.key}}</h4>
+        <h5>{{detail.value}}</h5>
+    </div>
+  </div>
+
+  <div id="target-img-holder" class="small-7 columns">
+      <div ng-show="targetReviewCtrl.getReviewTarget()"
+          style="{{targetReviewCtrl.getTargetImgStyle()}}"></div>
+  </div>
+</div>
+

--- a/server/auvsi_suas/templates/auvsi_suas/index.html
+++ b/server/auvsi_suas/templates/auvsi_suas/index.html
@@ -51,6 +51,7 @@
   <link rel="stylesheet" href="{% static 'auvsi_suas/components/team-status/team-status.css'%}" />
   <link rel="stylesheet" href="{% static 'auvsi_suas/pages/mission-dashboard/mission-dashboard.css'%}" />
   <link rel="stylesheet" href="{% static 'auvsi_suas/pages/mission-list/mission-list.css'%}" />
+  <link rel="stylesheet" href="{% static 'auvsi_suas/pages/target-review/target-review.css'%}" />
 
   <script src="{% static 'auvsi_suas/app.js'%}"></script>
   <script src="{% static 'auvsi_suas/components/settings/settings-service.js'%}"></script>
@@ -63,6 +64,7 @@
   <script src="{% static 'auvsi_suas/components/team-status/team-status-controller.js'%}"></script>
   <script src="{% static 'auvsi_suas/pages/mission-dashboard/mission-dashboard-controller.js'%}"></script>
   <script src="{% static 'auvsi_suas/pages/mission-list/mission-list-controller.js'%}"></script>
+  <script src="{% static 'auvsi_suas/pages/target-review/target-review-controller.js'%}"></script>
 
   <title>AUVSI SUAS Server</title>
 </head>

--- a/server/auvsi_suas/views/targets.py
+++ b/server/auvsi_suas/views/targets.py
@@ -438,7 +438,7 @@ class TargetsAdminReview(View):
         """Updates the review status of a target."""
         try:
             data = json.loads(request.body)
-            approved = bool(data['approved'])
+            approved = bool(data['thumbnail_approved'])
         except KeyError:
             return HttpResponseBadRequest('Failed to get required field.')
         except ValueError:

--- a/server/auvsi_suas/views/targets_test.py
+++ b/server/auvsi_suas/views/targets_test.py
@@ -912,7 +912,7 @@ class TestTargetsAdminReview(TestCase):
         """Test PUT reivew with invalid pk."""
         response = self.client.put(
             targets_review_id_url(args=[1]),
-            data=json.dumps({'approved': False}))
+            data=json.dumps({'thumbnail_approved': False}))
         self.assertEqual(404, response.status_code)
 
     def test_put_review(self):
@@ -922,7 +922,7 @@ class TestTargetsAdminReview(TestCase):
 
         response = self.client.put(
             targets_review_id_url(args=[target.pk]),
-            data=json.dumps({'approved': False}))
+            data=json.dumps({'thumbnail_approved': False}))
         self.assertEqual(200, response.status_code)
         data = json.loads(response.content)
         self.assertIn('id', data)


### PR DESCRIPTION
Updates the backend review PUT to use the same field so it is directly
updatable by the Angular resource object.

Updates the menus for better organization of displays/tools. Updates the
help message on the dashboard.

Adds a new resource for target review requests. Adds a page to view
and update targets under review.

Fixes #54 