### PR TITLE
Review targets with image. Review in edit order.

### DIFF
--- a/server/auvsi_suas/views/targets.py
+++ b/server/auvsi_suas/views/targets.py
@@ -430,8 +430,14 @@ class TargetsAdminReview(View):
             if (MissionClockEvent.user_on_clock(user) or
                     MissionClockEvent.user_on_timeout(user)):
                 continue
-            targets.extend([t.json(is_superuser=request.user.is_superuser)
-                            for t in Target.objects.filter(user=user).all()])
+            # Get targets which have thumbnail.
+            targets.extend([t
+                            for t in Target.objects.filter(user=user).all()
+                            if t.thumbnail])
+        # Sort targets by last edit time, convert to json.
+        targets = [t.json(is_superuser=request.user.is_superuser)
+                   for t in sorted(targets,
+                                   key=lambda t: t.last_modified_time)]
         return JsonResponse(targets, safe=False)
 
     def put(self, request, pk):


### PR DESCRIPTION
Filter targets which don't have a thumbnail stored. Sort the final list
of targets by last edit time. This will provide a stable order for
reviewing.

Fixes #123 