### PR TITLE
Verify UAS remains along waypoint track

### DIFF
--- a/docs/management/configure_manage.rst
+++ b/docs/management/configure_manage.rst
@@ -146,7 +146,8 @@ The user must create a MissionConfig in order to test interoperability.
    mission. The active mission is used when responding to requests or storing
    data. The admin must make sure there is only one labeled active at a time.
 #. `Home pos` defines the home position. This is the center of the admin
-   display and should be where the ground station is.
+   display and should be where the ground station is. The mission is expected
+   to occur reasonably close to this position (i.e., within several miles).
 #. `Fly zones` define the valid areas where a UAS is considered in-bounds. This
    must include the takeoff and landing strip. This is used to evaluate time
    spent out of bounds.

--- a/server/auvsi_suas/fixtures/testdata/sample_mission.json
+++ b/server/auvsi_suas/fixtures/testdata/sample_mission.json
@@ -57,8 +57,8 @@
 },
 {
     "fields": {
-        "latitude": 10.0,
-        "longitude": 100.0
+        "latitude": 38.0,
+        "longitude": -79.0
     },
     "model": "auvsi_suas.gpsposition",
     "pk": 324

--- a/server/auvsi_suas/models/distance.py
+++ b/server/auvsi_suas/models/distance.py
@@ -1,7 +1,12 @@
 """Functions for computing distance."""
 
 import math
+import numpy as np
+import pyproj
+from django.conf import settings
 from auvsi_suas.models import units
+
+wgs84 = pyproj.Proj(init="epsg:4326")
 
 
 def haversine(lon1, lat1, lon2, lat2):
@@ -53,3 +58,122 @@ def distance_to(latitude_1, longitude_1, altitude_1, latitude_2, longitude_2,
     gps_dist_ft = units.kilometers_to_feet(gps_dist_km)
     alt_dist_ft = abs(altitude_1 - altitude_2)
     return math.hypot(gps_dist_ft, alt_dist_ft)
+
+
+def utm_zone(lat, lon):
+    """Determine the UTM zone for a given latitude and longitude.
+
+    Based on http://gis.stackexchange.com/a/13292
+
+    Args:
+        lat: Latitude
+        lon: Longitude
+
+    Returns:
+        zone number: UTM zone number lat/lon falls in
+        north: bool indicating North/South
+    """
+    zone = math.floor((lon + 180) / 6.0) + 1
+
+    # Special cases for Norway and Svalbard
+    if lat >= 56 and lat < 64 and lon >= 3 and lon < 12:
+        zone = 32
+
+    if lat >= 72 and lat < 84:
+        if lon >= 0 and lon < 9:
+            zone = 31
+        elif lon >= 9 and lon < 21:
+            zone = 33
+        elif lon >= 21 and lon < 33:
+            zone = 35
+        elif lon >= 33 and lon < 42:
+            zone = 37
+
+    return zone, lat > 0
+
+
+def proj_utm(zone, north):
+    """Proj instance for the given zone.
+
+    Args:
+        zone: UTM zone
+        north: North zone or south zone
+
+    Returns:
+        pyproj.Proj instance for the given zone
+    """
+    ref = "+proj=utm +zone=%d +ellps=WGS84" % zone
+    if not north:
+        reg += " +south"
+    return pyproj.Proj(ref)
+
+
+def distance_to_line(start, end, point, utm):
+    """Compute the closest distance from point to a line segment.
+
+    Based on the point-line distance derived in:
+    http://mathworld.wolfram.com/Point-LineDistance3-Dimensional.html
+
+          (l_1 - p) dot (l_2 - p)
+    t = - -----------------------
+               |l_2 - l_1|^2
+
+    We clamp t to 0 <= t <= 1 to ensure we calculate distance to a point on
+    the line segment.
+
+    The closest point can be determined using t:
+
+    p_c = l_1 + t * (l_2 - l_1)
+
+    And the distance is:
+
+    d = |p - p_c|
+
+    Arguments are points in the form (lat, lon, alt MSL (ft)).
+
+    Args:
+        start: Defines the start of the line.
+        end: Defines the end of the line.
+        point: Free point to compute distance from.
+        utm: The UTM Proj projection to project into. If start, end, or point
+             are well outside of this projection, this function returns
+             infinite.
+
+    Returns:
+        Closest distance in ft from point to the line.
+    """
+    try:
+        # Convert points to UTM projection.
+        # We need a cartesian coordinate system to perform the calculation.
+        lat, lon, ftmsl = start
+        x, y = pyproj.transform(wgs84, utm, lon, lat)
+        l1 = np.array([x, y, units.feet_to_meters(ftmsl)])
+
+        lat, lon, ftmsl = end
+        x, y = pyproj.transform(wgs84, utm, lon, lat)
+        l2 = np.array([x, y, units.feet_to_meters(ftmsl)])
+
+        lat, lon, ftmsl = point
+        x, y = pyproj.transform(wgs84, utm, lon, lat)
+        p = np.array([x, y, units.feet_to_meters(ftmsl)])
+    except RuntimeError:
+        # pyproj throws RuntimeError if the coordinates are grossly beyond the
+        # bounds of the projection. We simplify this to "infinite" distance.
+        return float("inf")
+
+    d1 = l1 - p
+    d2 = l2 - l1
+    num = np.dot(d1, d2)
+    dem = np.linalg.norm(l2 - l1)**2
+    t = -num / dem
+
+    if t < 0:
+        t = 0
+    elif t > 1:
+        t = 1
+
+    p_c = l1 + t * (l2 - l1)
+
+    dist = np.linalg.norm(p - p_c)
+
+    return units.meters_to_feet(dist)

--- a/server/auvsi_suas/models/distance_test.py
+++ b/server/auvsi_suas/models/distance_test.py
@@ -1,5 +1,6 @@
 """Tests for the distance module."""
 
+import pyproj
 from auvsi_suas.models import distance
 from django.test import TestCase
 
@@ -55,3 +56,72 @@ class TestHaversine(TestCase):
 
 
 # TODO: Add additional tests for distance_to()
+
+
+class TestDistanceToLine(TestCase):
+    """Tests distance_to_line."""
+
+    # Use UTM 18N for all test cases.
+    utm = distance.proj_utm(zone=18, north=True)
+
+    def evaluate_inputs(self, inputs):
+        """Evaluates a list of test cases."""
+        for start, end, point, expected in inputs:
+            dist = distance.distance_to_line(start, end, point, utm=self.utm)
+            self.assertAlmostEqual(expected, dist, delta=5)  # ft
+
+    def test_at_points(self):
+        """Test inputs that are at or near the end points."""
+        self.evaluate_inputs([
+            # (start,        end,            point,          dist)
+            ((38, -76, 100), (38, -77, 100), (38, -76, 100), 0),
+            ((38, -76, 100), (38, -77, 100), (38, -77, 100), 0),
+            ((38, -76, 100), (38, -77, 100), (38, -77, 0),   100),
+            ((38, -76, 100), (38, -77, 100), (38, -77, 200), 100),
+        ])  # yapf: disable
+
+    def test_midpoint(self):
+        """Test inputs that are along the middle of the line."""
+        self.evaluate_inputs([
+            (
+                (38.145148, -76.427645, 100),  # start
+                (38.145144, -76.426400, 100),  # end
+                (38.145000, -76.427081, 100),  # point
+                58,  # dist
+            ),
+            (
+                (38.145148, -76.427645, 100),  # start
+                (38.145144, -76.426400, 200),  # end
+                (38.145000, -76.427081, 100),  # point
+                70,  # dist
+            ),
+        ])  # yapf: disable
+
+    def test_beyond_points(self):
+        """Test inputs that are beyond the end of the line segment."""
+        self.evaluate_inputs([
+            (
+                (38.145148, -76.427645, 100),  # start
+                (38.145144, -76.426400, 100),  # end
+                (38.145165, -76.427923, 100),  # point
+                80,  # dist
+            ),
+            (
+                (38.145148, -76.427645, 100),  # start
+                (38.145144, -76.426400, 100),  # end
+                (38.145591, -76.426127, 200),  # point
+                207,  # dist
+            ),
+        ])  # yapf: disable
+
+    def test_bad_input(self):
+        """Test inputs well outside the projection return infinite."""
+        # The last of these are on top of one another, but stil return infinite
+        # because they are too far beyond the projection zone.
+        self.evaluate_inputs([
+            # (start,        end,            point,          dist)
+            ((0, 100, 0),    (38, -77, 100), (38, -76, 100), float("inf")),
+            ((38, -76, 100), (0, 100, 0),    (38, -77, 100), float("inf")),
+            ((38, -76, 100), (38, -77, 100), (0, 100, 0),    float("inf")),
+            ((0, 100, 0),    (0, 100, 0),    (0, 100, 0),    float("inf")),
+        ])  # yapf: disable

--- a/server/auvsi_suas/models/units.py
+++ b/server/auvsi_suas/models/units.py
@@ -1,6 +1,17 @@
 """Functions for converting between units."""
 
 
+def meters_to_feet(meters):
+    """Converts meters to feet.
+
+    Args:
+        meters: A distance in meters.
+    Returns:
+        A distance in feet.
+    """
+    return meters / 0.3048
+
+
 def kilometers_to_feet(kilometers):
     """Converts kilometers to feet.
 
@@ -9,7 +20,7 @@ def kilometers_to_feet(kilometers):
     Returns:
         A distance in feet.
     """
-    return kilometers * 3280.8399
+    return meters_to_feet(1000 * kilometers)
 
 
 def feet_to_meters(feet):

--- a/server/auvsi_suas/models/units_test.py
+++ b/server/auvsi_suas/models/units_test.py
@@ -4,6 +4,24 @@ from auvsi_suas.models import units
 from django.test import TestCase
 
 
+class TestMetersToFeet(TestCase):
+    """Tests the conversion from meters to feet."""
+
+    def test_m_to_ft(self):
+        """Performs a data-driven test of the conversion."""
+        cases = [
+            # (m, ft_actual)
+            (  0,     0),
+            (  1,     3.28084),
+            (  1.5,   4.92126),
+            (100,   328.084),
+        ]  # yapf: disable
+        for (km, ft_actual) in cases:
+            self.assertAlmostEqual(ft_actual,
+                                   units.meters_to_feet(km),
+                                   delta=5)
+
+
 class TestKilometersToFeet(TestCase):
     """Tests the conversion from kilometers to feet."""
 

--- a/server/auvsi_suas/views/missions_test.py
+++ b/server/auvsi_suas/views/missions_test.py
@@ -186,8 +186,8 @@ class TestMissionsViewSampleMission(TestMissionsViewCommon):
         self.assertIn('home_pos', data[0])
         self.assertIn('latitude', data[0]['home_pos'])
         self.assertIn('longitude', data[0]['home_pos'])
-        self.assertEqual(10.0, data[0]['home_pos']['latitude'])
-        self.assertEqual(100.0, data[0]['home_pos']['longitude'])
+        self.assertEqual(38.0, data[0]['home_pos']['latitude'])
+        self.assertEqual(-79.0, data[0]['home_pos']['longitude'])
 
         self.assertIn('mission_waypoints', data[0])
         for waypoint in data[0]['mission_waypoints']:
@@ -222,8 +222,8 @@ class TestMissionsViewSampleMission(TestMissionsViewCommon):
         self.assertEqual(1, len(data[0]['search_grid_points']))
 
         self.assertEqual(150, data[0]['search_grid_points'][0]['id'])
-        self.assertEqual(10.0, data[0]['search_grid_points'][0]['latitude'])
-        self.assertEqual(100.0, data[0]['search_grid_points'][0]['longitude'])
+        self.assertEqual(38.0, data[0]['search_grid_points'][0]['latitude'])
+        self.assertEqual(-79.0, data[0]['search_grid_points'][0]['longitude'])
         self.assertEqual(1000.0,
                          data[0]['search_grid_points'][0]['altitude_msl'])
         self.assertEqual(10, data[0]['search_grid_points'][0]['order'])
@@ -231,24 +231,24 @@ class TestMissionsViewSampleMission(TestMissionsViewCommon):
         self.assertIn('emergent_last_known_pos', data[0])
         self.assertIn('latitude', data[0]['emergent_last_known_pos'])
         self.assertIn('longitude', data[0]['emergent_last_known_pos'])
-        self.assertEqual(10.0, data[0]['emergent_last_known_pos']['latitude'])
-        self.assertEqual(100.0,
+        self.assertEqual(38.0, data[0]['emergent_last_known_pos']['latitude'])
+        self.assertEqual(-79.0,
                          data[0]['emergent_last_known_pos']['longitude'])
 
         self.assertIn('off_axis_target_pos', data[0])
         self.assertIn('latitude', data[0]['off_axis_target_pos'])
         self.assertIn('longitude', data[0]['off_axis_target_pos'])
-        self.assertEqual(10.0, data[0]['off_axis_target_pos']['latitude'])
-        self.assertEqual(100.0, data[0]['off_axis_target_pos']['longitude'])
+        self.assertEqual(38.0, data[0]['off_axis_target_pos']['latitude'])
+        self.assertEqual(-79.0, data[0]['off_axis_target_pos']['longitude'])
 
         self.assertIn('sric_pos', data[0])
         self.assertIn('latitude', data[0]['sric_pos'])
         self.assertIn('longitude', data[0]['sric_pos'])
-        self.assertEqual(10.0, data[0]['sric_pos']['latitude'])
-        self.assertEqual(100.0, data[0]['sric_pos']['longitude'])
+        self.assertEqual(38.0, data[0]['sric_pos']['latitude'])
+        self.assertEqual(-79.0, data[0]['sric_pos']['longitude'])
 
         self.assertIn('air_drop_pos', data[0])
         self.assertIn('latitude', data[0]['air_drop_pos'])
         self.assertIn('longitude', data[0]['air_drop_pos'])
-        self.assertEqual(10.0, data[0]['air_drop_pos']['latitude'])
-        self.assertEqual(100.0, data[0]['air_drop_pos']['longitude'])
+        self.assertEqual(38.0, data[0]['air_drop_pos']['latitude'])
+        self.assertEqual(-79.0, data[0]['air_drop_pos']['longitude'])

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -8,6 +8,7 @@ networkx
 numpy
 pillow
 psycopg2
+pyproj
 PyYAML # for loaddata
 scipy
 simplekml==1.2.7

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -181,6 +181,9 @@ TEST_LOADTEST_INTEROP_MIN_RATE = 1.5 * 10.0 * 4
 # The max distance for a waypoint to be considered satisfied.
 SATISFIED_WAYPOINT_DIST_MAX_FT = 50
 
+# The max distance for a UAS to diverge from the waypoint track.
+WAYPOINT_TRACK_DIST_MAX_FT = 100
+
 # The max number of autonomous targets.
 TARGET_MAX_NUM_AUTONOMOUS = 6
 

--- a/setup/puppet_files/auvsi_suas/manifests/server_install.pp
+++ b/setup/puppet_files/auvsi_suas/manifests/server_install.pp
@@ -7,6 +7,7 @@ class auvsi_suas::server_install {
 
     # Install packages from apt.
     $package_deps = [
+        'python-pyproj',
         'python-numpy',
         'python-scipy',
         'python-matplotlib',
@@ -23,8 +24,9 @@ class auvsi_suas::server_install {
         requirements => '/interop/server/requirements.txt',
         # We install some packages from apt since that is much faster.
         systempkgs => true,
-        require => [ Package['python-numpy'], Package['python-scipy'],
-                     Package['python-matplotlib'], Package['python-psycopg2'] ]
+        require => [ Package['python-pyproj'], Package['python-numpy'],
+                     Package['python-scipy'], Package['python-matplotlib'],
+                     Package['python-psycopg2'] ]
     }
 
     # Link NodeJS (installed as nodejs) so that Karma can use it as node.


### PR DESCRIPTION
When evaluating waypoints, verify that every UAS telemetry point remains
within 100ft of the straight-line waypoint track.

To achieve this, we convert WGS84 coordinates into a cartesian
coordinate system (UTM), where we can do simply vector arithmetic to
determine the distance from the waypoint track line segment.

Fixes #71