### PR TITLE
Drop wrap content starting with text/html

### DIFF
--- a/server/server/debug.py
+++ b/server/server/debug.py
@@ -19,7 +19,7 @@ class NonHtmlDebugToolbarMiddleware(object):
                 new_content = '<html><body>Binary Data, ' \
                     'Length: {}</body></html>'.format(len(response.content))
                 response = HttpResponse(new_content)
-            elif response['Content-Type'] != 'text/html':
+            elif not response['Content-Type'].startswith('text/html'):
                 content = response.content
                 try:
                     json_ = json.loads(content)


### PR DESCRIPTION
New versions of Django give HTML responses with the content type
'text/html; charset: utf-8'. We don't want to wrap that, so only check
for a start of text/html.