### PR TITLE
Convert AccessLog to an abstract base class

### DIFF
--- a/server/auvsi_suas/fixtures/testdata/sample_mission.json
+++ b/server/auvsi_suas/fixtures/testdata/sample_mission.json
@@ -572,7 +572,9 @@
 {
     "fields": {
         "uas_position": 178,
-        "uas_heading": 0.0
+        "uas_heading": 0.0,
+        "timestamp": "1970-01-01T00:00:00Z",
+        "user": 53
     },
     "model": "auvsi_suas.uastelemetry",
     "pk": 148
@@ -580,7 +582,9 @@
 {
     "fields": {
         "uas_position": 179,
-        "uas_heading": 0.0
+        "uas_heading": 0.0,
+        "timestamp": "1970-01-01T00:00:00.100Z",
+        "user": 53
     },
     "model": "auvsi_suas.uastelemetry",
     "pk": 149
@@ -588,7 +592,9 @@
 {
     "fields": {
         "uas_position": 180,
-        "uas_heading": 0.0
+        "uas_heading": 0.0,
+        "timestamp": "1970-01-01T00:00:00.200Z",
+        "user": 53
     },
     "model": "auvsi_suas.uastelemetry",
     "pk": 150
@@ -596,7 +602,9 @@
 {
     "fields": {
         "uas_position": 181,
-        "uas_heading": 0.0
+        "uas_heading": 0.0,
+        "timestamp": "1970-01-01T00:00:00.300Z",
+        "user": 53
     },
     "model": "auvsi_suas.uastelemetry",
     "pk": 151
@@ -604,7 +612,9 @@
 {
     "fields": {
         "uas_position": 182,
-        "uas_heading": 0.0
+        "uas_heading": 0.0,
+        "timestamp": "1970-01-01T00:00:00.800Z",
+        "user": 53
     },
     "model": "auvsi_suas.uastelemetry",
     "pk": 152
@@ -612,7 +622,9 @@
 {
     "fields": {
         "uas_position": 183,
-        "uas_heading": 0.0
+        "uas_heading": 0.0,
+        "timestamp": "1970-01-01T00:00:01Z",
+        "user": 54
     },
     "model": "auvsi_suas.uastelemetry",
     "pk": 161
@@ -620,7 +632,9 @@
 {
     "fields": {
         "uas_position": 184,
-        "uas_heading": 0.0
+        "uas_heading": 0.0,
+        "timestamp": "1970-01-01T00:00:02Z",
+        "user": 54
     },
     "model": "auvsi_suas.uastelemetry",
     "pk": 162
@@ -628,7 +642,9 @@
 {
     "fields": {
         "uas_position": 184,
-        "uas_heading": 0.0
+        "uas_heading": 0.0,
+        "timestamp": "1970-01-01T00:00:03Z",
+        "user": 54
     },
     "model": "auvsi_suas.uastelemetry",
     "pk": 163
@@ -755,191 +771,64 @@
 },
 {
     "fields": {
-        "uas_in_air": true
+        "uas_in_air": true,
+        "timestamp": "1970-01-01T00:00:00Z",
+        "user": 53
     },
     "model": "auvsi_suas.takeofforlandingevent",
     "pk": 137
 },
 {
     "fields": {
-        "uas_in_air": false
+        "uas_in_air": false,
+        "timestamp": "1970-01-01T00:00:01Z",
+        "user": 53
     },
     "model": "auvsi_suas.takeofforlandingevent",
     "pk": 138
 },
 {
     "fields": {
-        "uas_in_air": true
+        "uas_in_air": true,
+        "timestamp": "1970-01-01T00:00:01Z",
+        "user": 54
     },
     "model": "auvsi_suas.takeofforlandingevent",
     "pk": 153
 },
 {
     "fields": {
-        "uas_in_air": false
+        "uas_in_air": false,
+        "timestamp": "1970-01-01T00:00:02Z",
+        "user": 54
     },
     "model": "auvsi_suas.takeofforlandingevent",
     "pk": 154
 },
 {
     "fields": {
-        "uas_in_air": true
+        "uas_in_air": true,
+        "timestamp": "1970-01-01T00:00:09Z",
+        "user": 54
     },
     "model": "auvsi_suas.takeofforlandingevent",
     "pk": 164
 },
 {
     "fields": {
-        "uas_in_air": false
+        "uas_in_air": false,
+        "timestamp": "1970-01-01T00:00:10Z",
+        "user": 54
     },
     "model": "auvsi_suas.takeofforlandingevent",
     "pk": 165
 },
 {
-    "fields": {},
-    "model": "auvsi_suas.serverinfoaccesslog",
-    "pk": 139
-},
-{
-    "fields": {},
-    "model": "auvsi_suas.serverinfoaccesslog",
-    "pk": 140
-},
-{
-    "fields": {},
-    "model": "auvsi_suas.serverinfoaccesslog",
-    "pk": 141
-},
-{
-    "fields": {},
-    "model": "auvsi_suas.serverinfoaccesslog",
-    "pk": 142
-},
-{
-    "fields": {},
-    "model": "auvsi_suas.serverinfoaccesslog",
-    "pk": 143
-},
-{
-    "fields": {},
-    "model": "auvsi_suas.serverinfoaccesslog",
-    "pk": 155
-},
-{
-    "fields": {},
-    "model": "auvsi_suas.serverinfoaccesslog",
-    "pk": 156
-},
-{
-    "fields": {},
-    "model": "auvsi_suas.serverinfoaccesslog",
-    "pk": 157
-},
-{
-    "fields": {},
-    "model": "auvsi_suas.obstacleaccesslog",
-    "pk": 144
-},
-{
-    "fields": {},
-    "model": "auvsi_suas.obstacleaccesslog",
-    "pk": 145
-},
-{
-    "fields": {},
-    "model": "auvsi_suas.obstacleaccesslog",
-    "pk": 146
-},
-{
-    "fields": {},
-    "model": "auvsi_suas.obstacleaccesslog",
-    "pk": 147
-},
-{
-    "fields": {},
-    "model": "auvsi_suas.obstacleaccesslog",
-    "pk": 158
-},
-{
-    "fields": {},
-    "model": "auvsi_suas.obstacleaccesslog",
-    "pk": 159
-},
-{
-    "fields": {},
-    "model": "auvsi_suas.obstacleaccesslog",
-    "pk": 160
-},
-{
-    "fields": {
-        "team_on_timeout": false,
-        "team_on_clock": true
-    },
-    "model": "auvsi_suas.missionclockevent",
-    "pk": 166
-},
-{
-    "fields": {
-        "team_on_timeout": false,
-        "team_on_clock": false
-    },
-    "model": "auvsi_suas.missionclockevent",
-    "pk": 167
-},
-{
-    "fields": {
-        "team_on_timeout": false,
-        "team_on_clock": true
-    },
-    "model": "auvsi_suas.missionclockevent",
-    "pk": 168
-},
-{
-    "fields": {
-        "team_on_timeout": true,
-        "team_on_clock": false
-    },
-    "model": "auvsi_suas.missionclockevent",
-    "pk": 169
-},
-{
-    "fields": {
-        "team_on_timeout": false,
-        "team_on_clock": true
-    },
-    "model": "auvsi_suas.missionclockevent",
-    "pk": 170
-},
-{
-    "fields": {
-        "team_on_timeout": false,
-        "team_on_clock": false
-    },
-    "model": "auvsi_suas.missionclockevent",
-    "pk": 171
-},
-{
     "fields": {
         "timestamp": "1970-01-01T00:00:00Z",
         "user": 53
     },
-    "model": "auvsi_suas.accesslog",
-    "pk": 137
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:01Z",
-        "user": 53
-    },
-    "model": "auvsi_suas.accesslog",
-    "pk": 138
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:00Z",
-        "user": 53
-    },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.serverinfoaccesslog",
     "pk": 139
 },
 {
@@ -947,7 +836,7 @@
         "timestamp": "1970-01-01T00:00:00.200Z",
         "user": 53
     },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.serverinfoaccesslog",
     "pk": 140
 },
 {
@@ -955,7 +844,7 @@
         "timestamp": "1970-01-01T00:00:00.300Z",
         "user": 53
     },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.serverinfoaccesslog",
     "pk": 141
 },
 {
@@ -963,7 +852,7 @@
         "timestamp": "1970-01-01T00:00:00.400Z",
         "user": 53
     },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.serverinfoaccesslog",
     "pk": 142
 },
 {
@@ -971,103 +860,15 @@
         "timestamp": "1970-01-01T00:00:00.800Z",
         "user": 53
     },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.serverinfoaccesslog",
     "pk": 143
 },
 {
     "fields": {
         "timestamp": "1970-01-01T00:00:00Z",
-        "user": 53
-    },
-    "model": "auvsi_suas.accesslog",
-    "pk": 144
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:00.100Z",
-        "user": 53
-    },
-    "model": "auvsi_suas.accesslog",
-    "pk": 145
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:00.600Z",
-        "user": 53
-    },
-    "model": "auvsi_suas.accesslog",
-    "pk": 146
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:00.700Z",
-        "user": 53
-    },
-    "model": "auvsi_suas.accesslog",
-    "pk": 147
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:00Z",
-        "user": 53
-    },
-    "model": "auvsi_suas.accesslog",
-    "pk": 148
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:00.100Z",
-        "user": 53
-    },
-    "model": "auvsi_suas.accesslog",
-    "pk": 149
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:00.200Z",
-        "user": 53
-    },
-    "model": "auvsi_suas.accesslog",
-    "pk": 150
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:00.300Z",
-        "user": 53
-    },
-    "model": "auvsi_suas.accesslog",
-    "pk": 151
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:00.800Z",
-        "user": 53
-    },
-    "model": "auvsi_suas.accesslog",
-    "pk": 152
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:01Z",
         "user": 54
     },
-    "model": "auvsi_suas.accesslog",
-    "pk": 153
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:02Z",
-        "user": 54
-    },
-    "model": "auvsi_suas.accesslog",
-    "pk": 154
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:00Z",
-        "user": 54
-    },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.serverinfoaccesslog",
     "pk": 155
 },
 {
@@ -1075,7 +876,7 @@
         "timestamp": "1970-01-01T00:00:01.100Z",
         "user": 54
     },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.serverinfoaccesslog",
     "pk": 156
 },
 {
@@ -1083,15 +884,47 @@
         "timestamp": "1970-01-01T00:00:01.500Z",
         "user": 54
     },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.serverinfoaccesslog",
     "pk": 157
+},
+{
+    "fields": {
+        "timestamp": "1970-01-01T00:00:00Z",
+        "user": 53
+    },
+    "model": "auvsi_suas.obstacleaccesslog",
+    "pk": 144
+},
+{
+    "fields": {
+        "timestamp": "1970-01-01T00:00:00.100Z",
+        "user": 53
+    },
+    "model": "auvsi_suas.obstacleaccesslog",
+    "pk": 145
+},
+{
+    "fields": {
+        "timestamp": "1970-01-01T00:00:00.600Z",
+        "user": 53
+    },
+    "model": "auvsi_suas.obstacleaccesslog",
+    "pk": 146
+},
+{
+    "fields": {
+        "timestamp": "1970-01-01T00:00:00.700Z",
+        "user": 53
+    },
+    "model": "auvsi_suas.obstacleaccesslog",
+    "pk": 147
 },
 {
     "fields": {
         "timestamp": "1970-01-01T00:00:01.100Z",
         "user": 54
     },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.obstacleaccesslog",
     "pk": 158
 },
 {
@@ -1099,7 +932,7 @@
         "timestamp": "1970-01-01T00:00:01.200Z",
         "user": 54
     },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.obstacleaccesslog",
     "pk": 159
 },
 {
@@ -1107,95 +940,67 @@
         "timestamp": "1970-01-01T00:00:01.600Z",
         "user": 54
     },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.obstacleaccesslog",
     "pk": 160
 },
 {
     "fields": {
-        "timestamp": "1970-01-01T00:00:01Z",
-        "user": 54
-    },
-    "model": "auvsi_suas.accesslog",
-    "pk": 161
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:02Z",
-        "user": 54
-    },
-    "model": "auvsi_suas.accesslog",
-    "pk": 162
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:03Z",
-        "user": 54
-    },
-    "model": "auvsi_suas.accesslog",
-    "pk": 163
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:09Z",
-        "user": 54
-    },
-    "model": "auvsi_suas.accesslog",
-    "pk": 164
-},
-{
-    "fields": {
-        "timestamp": "1970-01-01T00:00:10Z",
-        "user": 54
-    },
-    "model": "auvsi_suas.accesslog",
-    "pk": 165
-},
-{
-    "fields": {
+        "team_on_timeout": false,
+        "team_on_clock": true,
         "timestamp": "1970-01-01T00:00:00Z",
         "user": 53
     },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.missionclockevent",
     "pk": 166
 },
 {
     "fields": {
+        "team_on_timeout": false,
+        "team_on_clock": false,
         "timestamp": "1970-01-01T00:00:02Z",
         "user": 53
     },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.missionclockevent",
     "pk": 167
 },
 {
     "fields": {
+        "team_on_timeout": false,
+        "team_on_clock": true,
         "timestamp": "1970-01-01T00:00:00Z",
         "user": 54
     },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.missionclockevent",
     "pk": 168
 },
 {
     "fields": {
+        "team_on_timeout": true,
+        "team_on_clock": false,
         "timestamp": "1970-01-01T00:00:03Z",
         "user": 54
     },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.missionclockevent",
     "pk": 169
 },
 {
     "fields": {
+        "team_on_timeout": false,
+        "team_on_clock": true,
         "timestamp": "1970-01-01T00:00:05Z",
         "user": 54
     },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.missionclockevent",
     "pk": 170
 },
 {
     "fields": {
+        "team_on_timeout": false,
+        "team_on_clock": false,
         "timestamp": "1970-01-01T00:00:20Z",
         "user": 54
     },
-    "model": "auvsi_suas.accesslog",
+    "model": "auvsi_suas.missionclockevent",
     "pk": 171
 }
 ]

--- a/server/auvsi_suas/migrations/0018_accesslog.py
+++ b/server/auvsi_suas/migrations/0018_accesslog.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+"""This two-part migration converts AccessLog to an abstract base class.
+
+Django is not capable of running a simple migration to move the AccessLog
+fields into the respective subtypes, so we must do an elaborate song-and-dance.
+
+1. Create new models in the final form we desire.
+2. Manually copy each entry from the old model to the new model.
+3. Delete the old models.
+
+In the next migration:
+4. Rename the new models to their final name (same as the old models).
+5. Delete the AccessLog model.
+
+The last two steps must be done in the next model because Django cannot handle
+both deleting the old models and renaming the new models to the old names
+within the same migration.
+"""
+
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+from django.utils import timezone
+from django.conf import settings
+import functools
+import logging
+
+big_migration = False
+
+
+def migration_warning(apps, scheme_editor):
+    ObstacleAccessLog = apps.get_model('auvsi_suas', 'obstacleaccesslog')
+    ServerInfoAccessLog = apps.get_model('auvsi_suas', 'serverinfoaccesslog')
+    UasTelemetry = apps.get_model('auvsi_suas', 'uastelemetry')
+
+    global big_migration
+    if ObstacleAccessLog.objects.count() > 10000:
+        big_migration = True
+    elif ServerInfoAccessLog.objects.count() > 10000:
+        big_migration = True
+    elif UasTelemetry.objects.count() > 10000:
+        big_migration = True
+
+    if big_migration:
+        print("""
+Warning: If you have a large database (e.g., >100k UasTelemetry objects)
+then this migration may take a long time and require a large amount of
+memory (>2GB).
+
+If the following migration asks for confirmation to remove the stale accesslog
+table, say yes.""")
+
+
+def copy_mission_clock_event(apps, scheme_editor):
+    if big_migration:
+        print('Copying MissionClockEvent')
+
+    MissionClockEvent = apps.get_model('auvsi_suas', 'missionclockevent')
+    NewMissionClockEvent = apps.get_model('auvsi_suas', 'newmissionclockevent')
+
+    for entry in MissionClockEvent.objects.all():
+        new = NewMissionClockEvent(timestamp=entry.timestamp,
+                                   user=entry.user,
+                                   team_on_clock=entry.team_on_clock,
+                                   team_on_timeout=entry.team_on_timeout)
+        new.save()
+
+
+def copy_obstacle_access_log(apps, scheme_editor):
+    if big_migration:
+        print('Copying ObstacleAccessLog')
+
+    ObstacleAccessLog = apps.get_model('auvsi_suas', 'obstacleaccesslog')
+    NewObstacleAccessLog = apps.get_model('auvsi_suas', 'newobstacleaccesslog')
+
+    for entry in ObstacleAccessLog.objects.all():
+        new = NewObstacleAccessLog(timestamp=entry.timestamp, user=entry.user)
+        new.save()
+
+
+def copy_server_info_access_log(apps, scheme_editor):
+    if big_migration:
+        print('Copying ServerInfoAccessLog')
+
+    ServerInfoAccessLog = apps.get_model('auvsi_suas', 'serverinfoaccesslog')
+    NewServerInfoAccessLog = apps.get_model('auvsi_suas',
+                                            'newserverinfoaccesslog')
+
+    for entry in ServerInfoAccessLog.objects.all():
+        new = NewServerInfoAccessLog(timestamp=entry.timestamp,
+                                     user=entry.user)
+        new.save()
+
+
+def copy_takeoff_or_landing_event(apps, scheme_editor):
+    if big_migration:
+        print('Copying TakeoffOrLandingEvent')
+
+    TakeoffOrLandingEvent = apps.get_model('auvsi_suas',
+                                           'takeofforlandingevent')
+    NewTakeoffOrLandingEvent = apps.get_model('auvsi_suas',
+                                              'newtakeofforlandingevent')
+
+    for entry in TakeoffOrLandingEvent.objects.all():
+        new = NewTakeoffOrLandingEvent(timestamp=entry.timestamp,
+                                       user=entry.user,
+                                       uas_in_air=entry.uas_in_air)
+        new.save()
+
+
+def copy_uas_telemetry(apps, scheme_editor):
+    if big_migration:
+        print('Copying UasTelemetry')
+
+    UasTelemetry = apps.get_model('auvsi_suas', 'uastelemetry')
+    NewUasTelemetry = apps.get_model('auvsi_suas', 'newuastelemetry')
+
+    for entry in UasTelemetry.objects.all():
+        new = NewUasTelemetry(timestamp=entry.timestamp,
+                              user=entry.user,
+                              uas_position=entry.uas_position,
+                              uas_heading=entry.uas_heading)
+        new.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('auvsi_suas', '0017_missionconfig_targets'),
+    ]
+
+    operations = [
+        migrations.RunPython(migration_warning),
+        migrations.CreateModel(
+            name='NewMissionClockEvent',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID',
+                                        serialize=False,
+                                        auto_created=True,
+                                        primary_key=True)),
+                # Use default instead of auto_now_add so that this can be
+                # overridden.
+                ('timestamp', models.DateTimeField(default=timezone.now,
+                                                   db_index=True)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('team_on_clock', models.BooleanField()),
+                ('team_on_timeout', models.BooleanField()),
+            ]),
+        migrations.RunPython(copy_mission_clock_event),
+        migrations.CreateModel(
+            name='NewObstacleAccessLog',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID',
+                                        serialize=False,
+                                        auto_created=True,
+                                        primary_key=True)),
+                ('timestamp', models.DateTimeField(default=timezone.now,
+                                                   db_index=True)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ]),
+        migrations.RunPython(copy_obstacle_access_log),
+        migrations.CreateModel(
+            name='NewServerInfoAccessLog',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID',
+                                        serialize=False,
+                                        auto_created=True,
+                                        primary_key=True)),
+                ('timestamp', models.DateTimeField(default=timezone.now,
+                                                   db_index=True)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ]),
+        migrations.RunPython(copy_server_info_access_log),
+        migrations.CreateModel(
+            name='NewTakeoffOrLandingEvent',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID',
+                                        serialize=False,
+                                        auto_created=True,
+                                        primary_key=True)),
+                ('timestamp', models.DateTimeField(default=timezone.now,
+                                                   db_index=True)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('uas_in_air', models.BooleanField()),
+            ]),
+        migrations.RunPython(copy_takeoff_or_landing_event),
+        migrations.CreateModel(
+            name='NewUasTelemetry',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID',
+                                        serialize=False,
+                                        auto_created=True,
+                                        primary_key=True)),
+                ('timestamp', models.DateTimeField(default=timezone.now,
+                                                   db_index=True)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('uas_position', models.ForeignKey(
+                    to='auvsi_suas.AerialPosition')),
+                ('uas_heading', models.FloatField()),
+            ]),
+        migrations.RunPython(copy_uas_telemetry),
+        migrations.DeleteModel(name='MissionClockEvent'),
+        migrations.DeleteModel(name='ObstacleAccessLog'),
+        migrations.DeleteModel(name='ServerInfoAccessLog'),
+        migrations.DeleteModel(name='TakeoffOrLandingEvent'),
+        migrations.DeleteModel(name='UasTelemetry'),
+        migrations.DeleteModel(name='AccessLog'),
+    ]

--- a/server/auvsi_suas/migrations/0019_accesslog_finish.py
+++ b/server/auvsi_suas/migrations/0019_accesslog_finish.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""See 0018_accesslog for the first stage of this migration."""
+
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+from django.utils import timezone
+from django.conf import settings
+import functools
+import logging
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('auvsi_suas', '0018_accesslog'),
+    ]
+
+    operations = [
+        migrations.RenameModel(old_name='NewMissionClockEvent',
+                               new_name='MissionClockEvent'),
+        migrations.RenameModel(old_name='NewObstacleAccessLog',
+                               new_name='ObstacleAccessLog'),
+        migrations.RenameModel(old_name='NewServerInfoAccessLog',
+                               new_name='ServerInfoAccessLog'),
+        migrations.RenameModel(old_name='NewTakeoffOrLandingEvent',
+                               new_name='TakeoffOrLandingEvent'),
+        migrations.RenameModel(old_name='NewUasTelemetry',
+                               new_name='UasTelemetry'),
+
+        # Back to auto_now_add.
+        migrations.AlterField(model_name='missionclockevent',
+                              name='timestamp',
+                              field=models.DateTimeField(auto_now_add=True,
+                                                         db_index=True)),
+        migrations.AlterField(model_name='obstacleaccesslog',
+                              name='timestamp',
+                              field=models.DateTimeField(auto_now_add=True,
+                                                         db_index=True)),
+        migrations.AlterField(model_name='serverinfoaccesslog',
+                              name='timestamp',
+                              field=models.DateTimeField(auto_now_add=True,
+                                                         db_index=True)),
+        migrations.AlterField(model_name='takeofforlandingevent',
+                              name='timestamp',
+                              field=models.DateTimeField(auto_now_add=True,
+                                                         db_index=True)),
+        migrations.AlterField(model_name='uastelemetry',
+                              name='timestamp',
+                              field=models.DateTimeField(auto_now_add=True,
+                                                         db_index=True)),
+    ]

--- a/server/auvsi_suas/models/access_log.py
+++ b/server/auvsi_suas/models/access_log.py
@@ -15,6 +15,9 @@ class AccessLog(models.Model):
     # The user which accessed the data
     user = models.ForeignKey(settings.AUTH_USER_MODEL, db_index=True)
 
+    class Meta:
+        abstract = True
+
     def __unicode__(self):
         """Descriptive text for use in displays."""
         return unicode("%s (pk:%s, user:%s, timestamp:%s)" %

--- a/server/auvsi_suas/models/access_log_test.py
+++ b/server/auvsi_suas/models/access_log_test.py
@@ -1,10 +1,20 @@
 """Tests for the access_log module."""
 
 import datetime
-from auvsi_suas.models import AccessLog, TimePeriod
+from auvsi_suas.models import AccessLog, ServerInfoAccessLog, TimePeriod
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.utils import timezone
+
+# We use ServerInfoAccessLog as a concrete version of AccessLog, which is
+# actually testable.
+
+
+class TestSanity(TestCase):
+    """Make sure ServerInfoAccessLog is a canonical AccessLog."""
+
+    def test_server_info_access_log(self):
+        self.assertTrue(issubclass(ServerInfoAccessLog, AccessLog))
 
 
 class TestAccessLogCommon(TestCase):
@@ -33,7 +43,7 @@ class TestAccessLogCommon(TestCase):
         logs = []
 
         for i in xrange(num):
-            log = AccessLog(user=user)
+            log = ServerInfoAccessLog(user=user)
             log.save()
             log.timestamp = start + i * delta
             log.save()
@@ -47,32 +57,32 @@ class TestAccessLogBasic(TestAccessLogCommon):
 
     def test_unicode(self):
         """Tests the unicode method executes."""
-        log = AccessLog(timestamp=timezone.now(), user=self.user1)
+        log = ServerInfoAccessLog(timestamp=timezone.now(), user=self.user1)
         log.save()
 
         log.__unicode__()
 
     def test_no_data(self):
-        log = AccessLog.last_for_user(self.user1)
+        log = ServerInfoAccessLog.last_for_user(self.user1)
         self.assertEqual(None, log)
 
-        logs = AccessLog.by_user(self.user1)
+        logs = ServerInfoAccessLog.by_user(self.user1)
         self.assertEqual(len(logs), 0)
 
-        logs = AccessLog.by_time_period(self.user1, [])
+        logs = ServerInfoAccessLog.by_time_period(self.user1, [])
         self.assertEqual(len(logs), 0)
 
-        log_rates = AccessLog.rates(self.user1, [])
+        log_rates = ServerInfoAccessLog.rates(self.user1, [])
         self.assertTupleEqual(log_rates, (None, None))
 
     def test_basic_access(self):
         start = timezone.now() - datetime.timedelta(seconds=10)
         logs = self.create_logs(self.user1, start=start)
 
-        log = AccessLog.last_for_user(self.user1)
+        log = ServerInfoAccessLog.last_for_user(self.user1)
         self.assertEqual(logs[-1], log)
 
-        results = AccessLog.by_user(self.user1)
+        results = ServerInfoAccessLog.by_user(self.user1)
         self.assertSequenceEqual(logs, results)
 
     def test_multi_user(self):
@@ -82,10 +92,10 @@ class TestAccessLogBasic(TestAccessLogCommon):
             logs += self.create_logs(self.user1, num=1)
             self.create_logs(self.user2, num=1)
 
-        log = AccessLog.last_for_user(self.user1)
+        log = ServerInfoAccessLog.last_for_user(self.user1)
         self.assertEqual(logs[-1], log)
 
-        results = AccessLog.by_user(self.user1)
+        results = ServerInfoAccessLog.by_user(self.user1)
         self.assertSequenceEqual(logs, results)
 
     def test_last_for_user_before_time(self):
@@ -94,7 +104,8 @@ class TestAccessLogBasic(TestAccessLogCommon):
         logs = self.create_logs(self.user1, num=10, start=start, delta=delta)
 
         before_time = start + delta * 3
-        log = AccessLog.last_for_user(self.user1, before_time=before_time)
+        log = ServerInfoAccessLog.last_for_user(self.user1,
+                                                before_time=before_time)
         self.assertEqual(logs[2], log)
 
     def test_user_active(self):
@@ -105,17 +116,20 @@ class TestAccessLogBasic(TestAccessLogCommon):
         latest_time = self.year2000 + 10 * delta
 
         # Active for user with recent logs
-        self.assertTrue(AccessLog.user_active(self.user1, base=latest_time))
+        self.assertTrue(ServerInfoAccessLog.user_active(self.user1,
+                                                        base=latest_time))
 
         # Not active for user with no logs
-        self.assertFalse(AccessLog.user_active(self.user2, base=latest_time))
+        self.assertFalse(ServerInfoAccessLog.user_active(self.user2,
+                                                         base=latest_time))
 
         # Not active for user with no recent logs
-        self.assertFalse(AccessLog.user_active(self.user1, base=self.year2001))
+        self.assertFalse(ServerInfoAccessLog.user_active(self.user1,
+                                                         base=self.year2001))
 
         # Active now
         self.create_logs(self.user1, num=10, delta=delta)
-        self.assertTrue(AccessLog.user_active(self.user1))
+        self.assertTrue(ServerInfoAccessLog.user_active(self.user1))
 
 
 class TestAccessLogByTimePeriod(TestAccessLogCommon):
@@ -134,7 +148,7 @@ class TestAccessLogByTimePeriod(TestAccessLogCommon):
 
     def test_single_period(self):
         """Single set of logs accessible."""
-        results = AccessLog.by_time_period(self.user1, [
+        results = ServerInfoAccessLog.by_time_period(self.user1, [
             TimePeriod(self.year2000, self.year2001)
         ])
 
@@ -142,7 +156,7 @@ class TestAccessLogByTimePeriod(TestAccessLogCommon):
 
     def test_full_range(self):
         """All logs from (-inf, inf)."""
-        results = AccessLog.by_time_period(self.user1, [
+        results = ServerInfoAccessLog.by_time_period(self.user1, [
             TimePeriod(None, None)
         ])
 
@@ -150,7 +164,7 @@ class TestAccessLogByTimePeriod(TestAccessLogCommon):
 
     def test_both_periods(self):
         """Both sets of logs, accesses individually."""
-        results = AccessLog.by_time_period(self.user1, [
+        results = ServerInfoAccessLog.by_time_period(self.user1, [
             TimePeriod(self.year2000, self.year2001),
             TimePeriod(self.year2003, self.year2004),
         ])
@@ -160,7 +174,7 @@ class TestAccessLogByTimePeriod(TestAccessLogCommon):
 
     def test_non_intersecting_period(self):
         """No logs matched."""
-        results = AccessLog.by_time_period(self.user1, [
+        results = ServerInfoAccessLog.by_time_period(self.user1, [
             TimePeriod(self.year2001, self.year2002),
         ])
 
@@ -168,7 +182,7 @@ class TestAccessLogByTimePeriod(TestAccessLogCommon):
 
     def test_one_intersecting_period(self):
         """Only one period matches logs."""
-        results = AccessLog.by_time_period(self.user1, [
+        results = ServerInfoAccessLog.by_time_period(self.user1, [
             TimePeriod(self.year2001, self.year2002),
             TimePeriod(self.year2003, self.year2004),
         ])
@@ -178,7 +192,7 @@ class TestAccessLogByTimePeriod(TestAccessLogCommon):
 
     def test_open_start(self):
         """Logs (-inf, 2001)"""
-        results = AccessLog.by_time_period(self.user1, [
+        results = ServerInfoAccessLog.by_time_period(self.user1, [
             TimePeriod(None, self.year2001),
         ])
 
@@ -186,7 +200,7 @@ class TestAccessLogByTimePeriod(TestAccessLogCommon):
 
     def test_open_end(self):
         """Logs (2003, inf)"""
-        results = AccessLog.by_time_period(self.user1, [
+        results = ServerInfoAccessLog.by_time_period(self.user1, [
             TimePeriod(self.year2003, None),
         ])
 
@@ -210,7 +224,7 @@ class TestAccessLogRates(TestAccessLogCommon):
         logs = self.create_logs(self.user1, delta=delta)
         period = self.consistent_period(logs, delta)
 
-        rates = AccessLog.rates(self.user1, [period])
+        rates = ServerInfoAccessLog.rates(self.user1, [period])
 
         self.assertSequenceEqual((1, 1), rates)
 
@@ -222,9 +236,9 @@ class TestAccessLogRates(TestAccessLogCommon):
         unused_logs = self.create_logs(self.user1, delta=delta)
         period = self.consistent_period(used_logs, delta)
 
-        rates = AccessLog.rates(self.user1,
-                                [period],
-                                time_period_logs=[used_logs])
+        rates = ServerInfoAccessLog.rates(self.user1,
+                                          [period],
+                                          time_period_logs=[used_logs])
 
         self.assertSequenceEqual((1, 1), rates)
 
@@ -235,7 +249,7 @@ class TestAccessLogRates(TestAccessLogCommon):
         logs = self.create_logs(self.user1, delta=delta)
         period = TimePeriod(None, None)
 
-        rates = AccessLog.rates(self.user1, [period])
+        rates = ServerInfoAccessLog.rates(self.user1, [period])
 
         self.assertSequenceEqual((1, 1), rates)
 
@@ -254,7 +268,7 @@ class TestAccessLogRates(TestAccessLogCommon):
 
         periods = [self.consistent_period(l, delta) for l in logs]
 
-        rates = AccessLog.rates(self.user1, periods)
+        rates = ServerInfoAccessLog.rates(self.user1, periods)
 
         self.assertSequenceEqual((1, 1), rates)
 
@@ -275,7 +289,7 @@ class TestAccessLogRates(TestAccessLogCommon):
 
         periods = [self.consistent_period(l, delta) for l in logs]
 
-        rates = AccessLog.rates(self.user1, periods)
+        rates = ServerInfoAccessLog.rates(self.user1, periods)
 
         self.assertAlmostEqual(1.0, rates[0])  # max
         self.assertAlmostEqual(0.75, rates[1], delta=0.001)  # avg

--- a/server/auvsi_suas/models/server_info_access_log_test.py
+++ b/server/auvsi_suas/models/server_info_access_log_test.py
@@ -1,1 +1,3 @@
 """Tests for the server_info_access_log module."""
+
+# Covered by access_log_test.py.


### PR DESCRIPTION
Making AccessLog an abstract base class means that rather than having a
dedicated AccessLog table in the database, each subtype's table contains
the AccessLog fields.

In my stress test, this makes the SQL queries for `/api/teams` go from
taking 6600ms total to 120ms.

The change itself is trivial, but the migration is complex, as Django
cannot gracefully handle this kind of migration. See 0018_accesslog.py
for details.

References #139