### PR TITLE
Enable the profiling panel on the debug toolbar

### DIFF
--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -61,6 +61,25 @@ if DEBUG:
     import debug
     MIDDLEWARE_CLASSES += debug.middleware
 
+# All of the default panels, plus the profiling panel.
+DEBUG_TOOLBAR_PANELS = [
+    'debug_toolbar.panels.versions.VersionsPanel',
+    'debug_toolbar.panels.timer.TimerPanel',
+    'debug_toolbar.panels.settings.SettingsPanel',
+    'debug_toolbar.panels.headers.HeadersPanel',
+    'debug_toolbar.panels.request.RequestPanel',
+    'debug_toolbar.panels.profiling.ProfilingPanel',
+    'debug_toolbar.panels.sql.SQLPanel',
+    'debug_toolbar.panels.staticfiles.StaticFilesPanel',
+    'debug_toolbar.panels.templates.TemplatesPanel',
+    'debug_toolbar.panels.cache.CachePanel',
+    'debug_toolbar.panels.signals.SignalsPanel',
+    'debug_toolbar.panels.logging.LoggingPanel',
+    'debug_toolbar.panels.redirects.RedirectsPanel',
+]
+
+DEBUG_TOOLBAR_CONFIG = {'PROFILER_MAX_DEPTH': 50}
+
 ROOT_URLCONF = 'server.urls'
 WSGI_APPLICATION = 'server.wsgi.application'
 


### PR DESCRIPTION
This gives a nice breakdown of where views are spending their time.
The max depth of 50 ensures we can actually see everything relevant.

References #139