### PR TITLE
Use Memcached over in-process cache.

### DIFF
--- a/client/interop/client_test.py
+++ b/client/interop/client_test.py
@@ -13,7 +13,9 @@ from . import Client, AsyncClient, InteropError, Target, Telemetry
 # if the defaults are not correct.
 server = os.getenv('TEST_INTEROP_SERVER', 'http://localhost')
 username = os.getenv('TEST_INTEROP_USER', 'testuser')
-password = os.getenv('TEST_INTEROP_PASS', 'testpass')
+password = os.getenv('TEST_INTEROP_USER_PASS', 'testpass')
+admin_username = os.getenv('TEST_INTEROP_ADMIN', 'testadmin')
+admin_password = os.getenv('TEST_INTEROP_ADMIN_PASS', 'testpass')
 
 
 class TestClientLoggedOut(unittest.TestCase):
@@ -51,6 +53,11 @@ class TestClient(unittest.TestCase):
 
     def setUp(self):
         """Create a logged in Client."""
+        # Create an admin client to clear cache.
+        client = Client(server, admin_username, admin_password)
+        client.get('/api/clear_cache')
+
+        # Test rest with non-admin clients.
         self.client = Client(server, username, password)
         self.async_client = AsyncClient(server, username, password)
 

--- a/server/auvsi_suas/test_runner.py
+++ b/server/auvsi_suas/test_runner.py
@@ -3,8 +3,9 @@
 import logging
 import shutil
 import tempfile
-from django.test import runner
 from django.conf import settings
+from django.core.cache import cache
+from django.test import runner
 
 
 class AuvsiSuasTestRunner(runner.DiscoverRunner):
@@ -29,6 +30,9 @@ class AuvsiSuasTestRunner(runner.DiscoverRunner):
         # Disable logging
         logging.disable(logging.CRITICAL)
 
+        # Clear any stale data in cache.
+        cache.clear()
+
     def teardown_test_environment(self):
         shutil.rmtree(settings.MEDIA_ROOT)
 
@@ -36,5 +40,8 @@ class AuvsiSuasTestRunner(runner.DiscoverRunner):
         settings.SENDFILE_BACKEND = self.sendfile_backend
 
         logging.disable(logging.NOTSET)
+
+        # Clear any test data in the cache.
+        cache.clear()
 
         super(AuvsiSuasTestRunner, self).teardown_test_environment()

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -4,6 +4,7 @@ django-debug-toolbar>=1.3
 django-sendfile
 iso8601
 matplotlib
+python-memcached
 networkx
 numpy
 pillow

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -103,12 +103,10 @@ DATABASES = {
 # https://docs.djangoproject.com/en/1.6/topics/cache
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
         'TIMEOUT': 30,
-        'OPTIONS': {
-            # At 1kB an object, 200MB
-            'MAX_ENTRIES': 200000
-        }
+        'KEY_PREFIX': 'suas',
     }
 }
 

--- a/setup/puppet_files/auvsi_suas/manifests/memcached_setup.pp
+++ b/setup/puppet_files/auvsi_suas/manifests/memcached_setup.pp
@@ -1,0 +1,13 @@
+# AUVSI SUAS Puppet Module: memcached_setup
+# Installs and configures memcached for the server.
+# ==============================================================================
+
+class auvsi_suas::memcached_setup {
+    class { 'memcached':
+        package_ensure => 'latest',
+        max_memory => 512,
+        listen_ip => '127.0.0.1',
+        tcp_port => 11211,
+        udp_port => 11211,
+    }
+}

--- a/setup/puppet_files/auvsi_suas/manifests/server_setup.pp
+++ b/setup/puppet_files/auvsi_suas/manifests/server_setup.pp
@@ -7,6 +7,8 @@ class auvsi_suas::server_setup {
     require auvsi_suas::server_install
     # ... and the database
     require auvsi_suas::postgresql_setup
+    # ... and the memcached
+    require auvsi_suas::memcached_setup
 
     # Prepare database
     exec { 'migrate':

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -68,6 +68,7 @@ ensure_puppet_module puppetlabs-postgresql
 ensure_puppet_module puppetlabs-apache
 ensure_puppet_module puppetlabs-nodejs
 ensure_puppet_module stankevich-python
+ensure_puppet_module saz-memcached
 
 # Launch the Puppet process. Prepares machine.
 log "Executing Puppet setup..."


### PR DESCRIPTION
This will create a consistent cache, which removes need to repeatedly
press a cache invalidation button, allows us to do proper invalidation
in the future, and allows us to use the cache for recent event queries
(e.g. latest telemetry data per user).

For #143 