### PR TITLE
Remove internal component ids within mission.

### DIFF
--- a/server/auvsi_suas/models/mission_config.py
+++ b/server/auvsi_suas/models/mission_config.py
@@ -372,19 +372,17 @@ class MissionConfig(models.Model):
             })
         for waypoint in self.mission_waypoints.all():
             ret['mission_waypoints'].append({
-                'id': waypoint.pk,
+                'order': waypoint.order,
                 'latitude': waypoint.position.gps_position.latitude,
                 'longitude': waypoint.position.gps_position.longitude,
                 'altitude_msl': waypoint.position.altitude_msl,
-                'order': waypoint.order,
             })
         for point in self.search_grid_points.all():
             ret['search_grid_points'].append({
-                'id': point.pk,
+                'order': point.order,
                 'latitude': point.position.gps_position.latitude,
                 'longitude': point.position.gps_position.longitude,
                 'altitude_msl': point.position.altitude_msl,
-                'order': point.order,
             })
         if not is_superuser:
             return ret
@@ -399,7 +397,6 @@ class MissionConfig(models.Model):
         })
         for obst in self.stationary_obstacles.all():
             ret['stationary_obstacles'].append({
-                'id': obst.pk,
                 'latitude': obst.gps_position.latitude,
                 'longitude': obst.gps_position.longitude,
                 'cylinder_radius': obst.cylinder_radius,
@@ -407,7 +404,6 @@ class MissionConfig(models.Model):
             })
         for obst in self.moving_obstacles.all():
             ret['moving_obstacles'].append({
-                'id': obst.pk,
                 'speed_avg': obst.speed_avg,
                 'sphere_radius': obst.sphere_radius,
             })

--- a/server/auvsi_suas/models/mission_config_test.py
+++ b/server/auvsi_suas/models/mission_config_test.py
@@ -317,41 +317,35 @@ class TestMissionConfigModelSampleMission(TestCase):
 
         self.assertIn('mission_waypoints', data)
         for waypoint in data['mission_waypoints']:
-            self.assertIn('id', waypoint)
+            self.assertIn('order', waypoint)
             self.assertIn('latitude', waypoint)
             self.assertIn('longitude', waypoint)
             self.assertIn('altitude_msl', waypoint)
-            self.assertIn('order', waypoint)
 
         self.assertEqual(2, len(data['mission_waypoints']))
-
-        self.assertEqual(155, data['mission_waypoints'][0]['id'])
+        self.assertEqual(0, data['mission_waypoints'][0]['order'])
         self.assertEqual(38.0, data['mission_waypoints'][0]['latitude'])
         self.assertEqual(-76.0, data['mission_waypoints'][0]['longitude'])
         self.assertEqual(30.0, data['mission_waypoints'][0]['altitude_msl'])
-        self.assertEqual(0, data['mission_waypoints'][0]['order'])
 
-        self.assertEqual(156, data['mission_waypoints'][1]['id'])
+        self.assertEqual(1, data['mission_waypoints'][1]['order'])
         self.assertEqual(38.0, data['mission_waypoints'][1]['latitude'])
         self.assertEqual(-77.0, data['mission_waypoints'][1]['longitude'])
         self.assertEqual(60.0, data['mission_waypoints'][1]['altitude_msl'])
-        self.assertEqual(1, data['mission_waypoints'][1]['order'])
 
         self.assertIn('search_grid_points', data)
         for point in data['search_grid_points']:
-            self.assertIn('id', point)
+            self.assertIn('order', point)
             self.assertIn('latitude', point)
             self.assertIn('longitude', point)
             self.assertIn('altitude_msl', point)
-            self.assertIn('order', point)
 
         self.assertEqual(1, len(data['search_grid_points']))
 
-        self.assertEqual(150, data['search_grid_points'][0]['id'])
+        self.assertEqual(10, data['search_grid_points'][0]['order'])
         self.assertEqual(38.0, data['search_grid_points'][0]['latitude'])
         self.assertEqual(-79.0, data['search_grid_points'][0]['longitude'])
         self.assertEqual(1000.0, data['search_grid_points'][0]['altitude_msl'])
-        self.assertEqual(10, data['search_grid_points'][0]['order'])
 
         self.assertIn('off_axis_target_pos', data)
         self.assertIn('latitude', data['off_axis_target_pos'])
@@ -396,12 +390,10 @@ class TestMissionConfigModelSampleMission(TestCase):
         self.assertIn('stationary_obstacles', data)
         self.assertEqual(2, len(data['stationary_obstacles']))
         for obst in data['stationary_obstacles']:
-            self.assertIn('id', obst)
             self.assertIn('latitude', obst)
             self.assertIn('longitude', obst)
             self.assertIn('cylinder_radius', obst)
             self.assertIn('cylinder_height', obst)
-        self.assertEqual(25, data['stationary_obstacles'][0]['id'])
         self.assertEqual(10.0,
                          data['stationary_obstacles'][0]['cylinder_height'])
         self.assertEqual(10.0,
@@ -412,10 +404,8 @@ class TestMissionConfigModelSampleMission(TestCase):
         self.assertIn('moving_obstacles', data)
         self.assertEqual(2, len(data['moving_obstacles']))
         for obst in data['moving_obstacles']:
-            self.assertIn('id', obst)
             self.assertIn('speed_avg', obst)
             self.assertIn('sphere_radius', obst)
-        self.assertEqual(25, data['moving_obstacles'][0]['id'])
         self.assertEqual(1.0, data['moving_obstacles'][0]['speed_avg'])
         self.assertEqual(15.0, data['moving_obstacles'][0]['sphere_radius'])
 

--- a/server/auvsi_suas/views/missions_test.py
+++ b/server/auvsi_suas/views/missions_test.py
@@ -184,42 +184,37 @@ class TestMissionsViewSampleMission(TestMissionsViewCommon):
 
         self.assertIn('mission_waypoints', data[0])
         for waypoint in data[0]['mission_waypoints']:
-            self.assertIn('id', waypoint)
+            self.assertIn('order', waypoint)
             self.assertIn('latitude', waypoint)
             self.assertIn('longitude', waypoint)
             self.assertIn('altitude_msl', waypoint)
-            self.assertIn('order', waypoint)
 
         self.assertEqual(2, len(data[0]['mission_waypoints']))
 
-        self.assertEqual(155, data[0]['mission_waypoints'][0]['id'])
+        self.assertEqual(0, data[0]['mission_waypoints'][0]['order'])
         self.assertEqual(38.0, data[0]['mission_waypoints'][0]['latitude'])
         self.assertEqual(-76.0, data[0]['mission_waypoints'][0]['longitude'])
         self.assertEqual(30.0, data[0]['mission_waypoints'][0]['altitude_msl'])
-        self.assertEqual(0, data[0]['mission_waypoints'][0]['order'])
 
-        self.assertEqual(156, data[0]['mission_waypoints'][1]['id'])
+        self.assertEqual(1, data[0]['mission_waypoints'][1]['order'])
         self.assertEqual(38.0, data[0]['mission_waypoints'][1]['latitude'])
         self.assertEqual(-77.0, data[0]['mission_waypoints'][1]['longitude'])
         self.assertEqual(60.0, data[0]['mission_waypoints'][1]['altitude_msl'])
-        self.assertEqual(1, data[0]['mission_waypoints'][1]['order'])
 
         self.assertIn('search_grid_points', data[0])
         for point in data[0]['search_grid_points']:
-            self.assertIn('id', point)
+            self.assertIn('order', point)
             self.assertIn('latitude', point)
             self.assertIn('longitude', point)
             self.assertIn('altitude_msl', point)
-            self.assertIn('order', point)
 
         self.assertEqual(1, len(data[0]['search_grid_points']))
 
-        self.assertEqual(150, data[0]['search_grid_points'][0]['id'])
+        self.assertEqual(10, data[0]['search_grid_points'][0]['order'])
         self.assertEqual(38.0, data[0]['search_grid_points'][0]['latitude'])
         self.assertEqual(-79.0, data[0]['search_grid_points'][0]['longitude'])
         self.assertEqual(1000.0,
                          data[0]['search_grid_points'][0]['altitude_msl'])
-        self.assertEqual(10, data[0]['search_grid_points'][0]['order'])
 
         self.assertIn('off_axis_target_pos', data[0])
         self.assertIn('latitude', data[0]['off_axis_target_pos'])


### PR DESCRIPTION
These IDs are internal implementation details not needed by the users of
the interface and provides unnecessary confusion.