### PR TITLE
Return telemetry in teams request. Index (user,timestamp) for telemetry.

### DIFF
--- a/server/auvsi_suas/fixtures/testdata/sample_mission.json
+++ b/server/auvsi_suas/fixtures/testdata/sample_mission.json
@@ -789,7 +789,7 @@
 {
     "fields": {
         "uas_in_air": false,
-        "timestamp": "1970-01-01T00:00:02Z",
+        "timestamp": "1970-01-01T00:00:03Z",
         "user": 54
     },
     "model": "auvsi_suas.takeofforlandingevent",
@@ -807,7 +807,7 @@
 {
     "fields": {
         "uas_in_air": false,
-        "timestamp": "1970-01-01T00:00:10Z",
+        "timestamp": "1970-01-01T00:00:11Z",
         "user": 54
     },
     "model": "auvsi_suas.takeofforlandingevent",

--- a/server/auvsi_suas/migrations/0023_index_together_user_timestamp.py
+++ b/server/auvsi_suas/migrations/0023_index_together_user_timestamp.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [('auvsi_suas', '0022_remove_missionconfig_sric_pos'), ]
+
+    operations = [
+        migrations.AlterIndexTogether(
+            name='missionclockevent',
+            index_together=set([('user', 'timestamp')]), ),
+        migrations.AlterIndexTogether(
+            name='takeofforlandingevent',
+            index_together=set([('user', 'timestamp')]), ),
+        migrations.AlterIndexTogether(
+            name='uastelemetry',
+            index_together=set([('user', 'timestamp')]), ),
+    ]

--- a/server/auvsi_suas/models/mission_clock_event.py
+++ b/server/auvsi_suas/models/mission_clock_event.py
@@ -34,7 +34,7 @@ class MissionClockEvent(AccessLog):
         Returns:
             True if the user currently on clock, False otherwise.
         """
-        event = cls.last_for_user(user, time)
+        event = cls.last_for_user(user, end_time=time)
         return event.team_on_clock if event else False
 
     @classmethod
@@ -47,7 +47,7 @@ class MissionClockEvent(AccessLog):
         Returns:
             True if user is on timeout, False otherwise.
         """
-        event = cls.last_for_user(user, time)
+        event = cls.last_for_user(user, end_time=time)
         return event.team_on_timeout if event else False
 
     @classmethod

--- a/server/auvsi_suas/models/mission_config_test.py
+++ b/server/auvsi_suas/models/mission_config_test.py
@@ -276,8 +276,8 @@ class TestMissionConfigModelSampleMission(TestCase):
         self.assertAlmostEqual(18, teams[user1]['mission_clock_time'])
         self.assertAlmostEqual(1.0, teams[user1]['out_of_bounds_time'])
 
-        self.assertAlmostEqual(1.0, teams[user1]['uas_telem_times']['max'])
-        self.assertAlmostEqual(2. / 4, teams[user1]['uas_telem_times']['avg'])
+        self.assertAlmostEqual(2.0, teams[user1]['uas_telem_times']['max'])
+        self.assertAlmostEqual(1.0, teams[user1]['uas_telem_times']['avg'])
 
         self.assertEqual(False, teams[user1]['stationary_obst_collision'][25])
         self.assertEqual(False, teams[user1]['stationary_obst_collision'][26])

--- a/server/auvsi_suas/models/takeoff_or_landing_event.py
+++ b/server/auvsi_suas/models/takeoff_or_landing_event.py
@@ -45,7 +45,7 @@ class TakeoffOrLandingEvent(AccessLog):
         Returns:
             True if user is currently in-flight, False otherwise
         """
-        event = cls.last_for_user(user, time)
+        event = cls.last_for_user(user, end_time=time)
         if event:
             return event.uas_in_air
         return False

--- a/server/auvsi_suas/models/uas_telemetry.py
+++ b/server/auvsi_suas/models/uas_telemetry.py
@@ -32,7 +32,7 @@ class UasTelemetry(AccessLog):
                         self.uas_position.__unicode__()))
 
     @classmethod
-    def by_user(cls, user):
+    def by_user(cls, *args, **kwargs):
         """Gets the time-sorted list of access log for the given user.
 
         Note: This prefetches the related AerialPosition and GpsPosition
@@ -47,7 +47,7 @@ class UasTelemetry(AccessLog):
         # Almost every user of UasTelemetry.by_user wants to use
         # the related AerialPosition and GpsPosition.  To avoid excessive
         # database queries, we select these values from the database up front.
-        return super(UasTelemetry, cls).by_user(user) \
+        return super(UasTelemetry, cls).by_user(*args, **kwargs) \
                 .select_related('uas_position__gps_position')
 
     @classmethod

--- a/server/auvsi_suas/static/auvsi_suas/components/team-status/team-status-controller.js
+++ b/server/auvsi_suas/static/auvsi_suas/components/team-status/team-status-controller.js
@@ -15,12 +15,8 @@ TeamStatusCtrl = function() {
      * @export {?Object} The team object, injected by directive.
      */
     this.team;
-
-    /**
-     * @export {?Object} The telemetry object, injected by directive.
-     */
-    this.telemetry;
 };
+
 
 /**
  * Gets the classes used to color a team's display on the dashboard.
@@ -29,7 +25,7 @@ TeamStatusCtrl = function() {
  */
 TeamStatusCtrl.prototype.getTeamColorClasses = function() {
     classes = [];
-    if (this.team.active) {
+    if (this.isActive()) {
         classes.push('team-status-active');
     }
     if (this.team.in_air) {
@@ -38,6 +34,27 @@ TeamStatusCtrl.prototype.getTeamColorClasses = function() {
     return classes.join(' ');
 };
 
+
+/**
+ * @return {!boolean} Whether the team is active.
+ * @export
+ */
+TeamStatusCtrl.prototype.isActive = function() {
+    return !!this.team.telemetry &&
+        new Date() - new Date(this.team.telemetry.timestamp) < 3000;
+};
+
+
+/**
+ * @return {!boolean} Whether to show the team.
+ * @export
+ */
+TeamStatusCtrl.prototype.shouldShow = function() {
+    return this.isActive() || this.team.in_air || this.team.on_clock ||
+           this.team.on_timeout;
+};
+
+
 // Register the directive.
 angular.module('auvsiSuasApp').directive('teamStatus', [
     function() {
@@ -45,8 +62,7 @@ angular.module('auvsiSuasApp').directive('teamStatus', [
             restrict: 'E',
             scope: {},
             bindToController: {
-                team: '=',
-                telemetry: '='
+                team: '='
             },
             controller: TeamStatusCtrl,
             controllerAs: 'teamStatusCtrl',

--- a/server/auvsi_suas/static/auvsi_suas/components/team-status/team-status-controller_test.js
+++ b/server/auvsi_suas/static/auvsi_suas/components/team-status/team-status-controller_test.js
@@ -9,30 +9,40 @@ describe("TeamStatusCtrl controller", function() {
 
     beforeEach(inject(function($controller) {
         team = {
-            active: true,
-            in_air: true
+            id: 4,
+            on_clock: false,
+            on_timeout: false,
+            telemetry: {
+                id: 10,
+                user: 4,
+                timestamp: '1990-10-01T00:00:00+00:00',
+                latitude: 38,
+                longitude: -76,
+                altitude_msl: 0,
+                heading: 90
+            },
+            in_air: false
         };
         teamStatusCtrl = new TeamStatusCtrl();
         teamStatusCtrl.team = team;
     }));
 
     it("Should get the team color class", function() {
-        expect(teamStatusCtrl.getTeamColorClasses())
-            .toEqual('team-status-active team-status-in-air');
-
         team.in_air = false;
-        team.active = true;
         expect(teamStatusCtrl.getTeamColorClasses())
-            .toEqual('team-status-active');
+            .toEqual('');
 
         team.in_air = true;
-        team.active = false;
         expect(teamStatusCtrl.getTeamColorClasses())
             .toEqual('team-status-in-air');
 
         team.in_air = false;
-        team.active = false;
+        team.telemetry.timestamp = '3000-10-01T00:00:00+00:00';
         expect(teamStatusCtrl.getTeamColorClasses())
-            .toEqual('');
+            .toEqual('team-status-active');
+
+        team.in_air = true;
+        expect(teamStatusCtrl.getTeamColorClasses())
+            .toEqual('team-status-active team-status-in-air');
     });
 });

--- a/server/auvsi_suas/static/auvsi_suas/components/team-status/team-status.html
+++ b/server/auvsi_suas/static/auvsi_suas/components/team-status/team-status.html
@@ -1,31 +1,31 @@
-<div class="panel team-status {{teamStatusCtrl.getTeamColorClasses()}}">
+<div class="panel team-status {{teamStatusCtrl.getTeamColorClasses()}}" ng-show="teamStatusCtrl.shouldShow()">
     <h4>{{teamStatusCtrl.team.id}}: {{teamStatusCtrl.team.name}}</h4>
-    <div class="row">
-        <div class="small-4 columns">
-            <h6>Lat: {{teamStatusCtrl.telemetry.latitude | number : 6}}</h6>
+    <div class="row team-status-telemetry">
+        <div title="Latitude in Degrees" class="small-4 columns">
+            Lat: {{teamStatusCtrl.team.telemetry.latitude | number : 6}}
         </div>
-        <div class="small-4 columns">
-            <h6>Lon: {{teamStatusCtrl.telemetry.longitude | number: 6}}</h6>
+        <div title="Longitude in Degrees" class="small-4 columns">
+            Lon: {{teamStatusCtrl.team.telemetry.longitude | number: 6}}
         </div>
-        <div class="small-4 columns">
-            <h6>Alt (ft MSL): {{teamStatusCtrl.telemetry.altitude_msl | number: 6}}</h6>
+        <div title="Altitude in Feet MSL" class="small-4 columns">
+            Alt: {{teamStatusCtrl.team.telemetry.altitude_msl | number: 1}}
         </div>
     </div>
     <div class="row">
         <div class="small-12 columns">
-            <span class="team-status-icon label" ng-if="teamStatusCtrl.team.on_clock"
+            <span class="team-status-icon label" ng-show="teamStatusCtrl.team.on_clock"
                   title="On Mission Clock">
                 &#128336;  <!-- CLOCK FACE ONE OCLOCK --!>
             </span>
-            <span class="team-status-icon label" ng-if="teamStatusCtrl.team.on_timeout"
+            <span class="team-status-icon label" ng-show="teamStatusCtrl.team.on_timeout"
                   title="On Timeout">
                 &#9208;  <!-- DOUBLE VERTICAL BAR --!>
             </span>
-            <span class="team-status-icon label" ng-if="teamStatusCtrl.team.active"
+            <span class="team-status-icon label" ng-show="teamStatusCtrl.isActive()"
                   title="Sending Telemtry">
                 &#8633;  <!-- LEFTWARDS ARROW TO BAR OVER RIGHTWARDS ARROW TO BAR --!>
             </span>
-            <span class="team-status-icon label" ng-if="teamStatusCtrl.team.in_air"
+            <span class="team-status-icon label" ng-show="teamStatusCtrl.team.in_air"
                   title="In Air">
                 &#9992;  <!-- AIRPLANE --!>
             </span>

--- a/server/auvsi_suas/static/auvsi_suas/pages/mission-dashboard/mission-dashboard-controller.js
+++ b/server/auvsi_suas/static/auvsi_suas/pages/mission-dashboard/mission-dashboard-controller.js
@@ -33,11 +33,6 @@ MissionDashboardCtrl = function($q, $rootScope, $routeParams, $interval,
     this.obstacles = null;
 
     /**
-     * @export {!Object} Map from user to telemetry data.
-     */
-    this.telemetry = {};
-
-    /**
      * @private @const {?Object} The scene built by the map view, via template.
      */
     this.missionScene = null;
@@ -79,39 +74,6 @@ MissionDashboardCtrl.prototype.getMission = function() {
 
 
 /**
- * Gets a list of teams which should be displayed.
- * @return {!Array} A list of teams.
- * @export
- */
-MissionDashboardCtrl.prototype.getTeamsToDisplay = function() {
-    // Check that data has been loaded.
-    if (!this.teams || this.teams.length == 0) {
-        return [];
-    }
-
-    // Get all teams which are relevant.
-    teams = [];
-    for (var i = 0; i < this.teams.length; i++) {
-        if (this.shouldDisplayTeam_(this.teams[i])) {
-            teams.push(this.teams[i]);
-        }
-    }
-    return teams;
-};
-
-
-/**
- * Gets the telemetry for a team.
- * @param{!Object} team The team for which to get telemetry.
- * @return {?Object} The telemetry for the team.
- * @export
- */
-MissionDashboardCtrl.prototype.getTelemetry = function(team) {
-    return this.telemetry[team.id];
-};
-
-
-/**
  * @param {!Object} mission The mission data.
  */
 MissionDashboardCtrl.prototype.setMission_ = function(mission) {
@@ -127,8 +89,7 @@ MissionDashboardCtrl.prototype.update_ = function() {
     // Execute backend requests.
     var requests = [];
     requests.push(this.backend_.teamsResource.query({}).$promise
-        .then(angular.bind(this, this.setTeams_))
-        .then(angular.bind(this, this.updateTelemetry_)));
+        .then(angular.bind(this, this.setTeams_)));
     requests.push(this.backend_.obstaclesResource.get({}).$promise.then(
             angular.bind(this, this.setObstacles_)));
 
@@ -158,39 +119,6 @@ MissionDashboardCtrl.prototype.setObstacles_ = function(obstacles) {
 
 
 /**
- * Updates the telemetry for active teams.
- * @return {!Object} Promise for updating telemetry requests.
- * @private
- */
-MissionDashboardCtrl.prototype.updateTelemetry_ = function() {
-    var requests = [];
-    for (var i = 0; i < this.teams.length; i++) {
-        if (this.teams[i].active) {
-            var query = this.backend_.telemetryResource.query({
-                limit: 1,
-                user: this.teams[i].id
-            });
-            requests.push(query.$promise.then(angular.bind(this, this.setTelemetry_)));
-        }
-    }
-    return this.q_.all(requests);
-}
-
-
-/**
- * Sets the telemetry.
- * @param {!Object} telemetry The telemetry to set.
- * @private
- */
-MissionDashboardCtrl.prototype.setTelemetry_ = function(telemetry) {
-    for (var i = 0; i < telemetry.length; i++) {
-        this.telemetry[telemetry[i].user] = telemetry[i];
-    }
-};
-
-
-
-/**
  * Rebuild the mission scene using the backend data.
  * @private
  */
@@ -203,8 +131,8 @@ MissionDashboardCtrl.prototype.rebuildMissionScene_ = function() {
     if (this.teams) {
         for (var i = 0; i < this.teams.length; i++) {
             var team = this.teams[i];
-            if (team.active && this.telemetry[team.id]) {
-                telemetry.push(this.telemetry[team.id]);
+            if (team.telemetry) {
+                telemetry.push(team.telemetry);
             }
         }
     }
@@ -214,17 +142,6 @@ MissionDashboardCtrl.prototype.rebuildMissionScene_ = function() {
         this.missionScene.rebuildScene(
                 this.mission, this.obstacles, telemetry);
     }
-};
-
-
-/**
- * Determines whether a team should be displayed.
- * @param {!Object} team The team to evaluate.
- * @return {!boolean} Whether team should be displayed.
- * @private
- */
-MissionDashboardCtrl.prototype.shouldDisplayTeam_ = function(team) {
-    return team.on_clock || team.on_timeout || team.active || team.in_air;
 };
 
 

--- a/server/auvsi_suas/static/auvsi_suas/pages/mission-dashboard/mission-dashboard-controller_test.js
+++ b/server/auvsi_suas/static/auvsi_suas/pages/mission-dashboard/mission-dashboard-controller_test.js
@@ -17,35 +17,43 @@ describe("MissionDashboardCtrl controller", function() {
                 id: 1,
                 on_clock: false,
                 on_timeout: false,
-                active: false,
+                telemetry: null,
                 in_air: false
             },
             {
                 id: 2,
                 on_clock: true,
                 on_timeout: false,
-                active: false,
+                telemetry: null,
                 in_air: false
             },
             {
                 id: 3,
                 on_clock: false,
                 on_timeout: true,
-                active: false,
+                telemetry: null,
                 in_air: false
             },
             {
                 id: 4,
                 on_clock: false,
                 on_timeout: false,
-                active: true,
+                telemetry: {
+                    id: 10,
+                    user: 4,
+                    timestamp: '3000-10-01T00:00:00+00:00',
+                    latitude: 38,
+                    longitude: -76,
+                    altitude_msl: 0,
+                    heading: 90
+                },
                 in_air: false
             },
             {
                 id: 5,
                 on_clock: false,
                 on_timeout: false,
-                active: false,
+                telemetry: null,
                 in_air: true
             },
         ];
@@ -66,8 +74,6 @@ describe("MissionDashboardCtrl controller", function() {
         httpBackend = $httpBackend;
         httpBackend.whenGET('/api/missions/1').respond({id: 1});
         httpBackend.whenGET('/api/teams').respond(teams);
-        httpBackend.whenGET('/api/telemetry?limit=1&user=4')
-            .respond([{user: 4, id: 10, latitude: 10}]);
         httpBackend.whenGET('/api/obstacles').respond({id: 300});
     }));
 
@@ -76,10 +82,11 @@ describe("MissionDashboardCtrl controller", function() {
         expect(missionDashboardCtrl.getMission().toJSON()).toEqual({id: 1});
     });
 
-    it("Should get teams to display", function() {
+    it("Should get teams", function() {
         interval.flush(2000);
         httpBackend.flush();
-        // Team 5 is not active, so expect 4.
-        expect(missionDashboardCtrl.getTeamsToDisplay().length).toEqual(4);
+        for (var i = 0; i < teams.length; i++) {
+            expect(missionDashboardCtrl.teams[i].toJSON()).toEqual(teams[i]);
+        }
     });
 });

--- a/server/auvsi_suas/static/auvsi_suas/pages/mission-dashboard/mission-dashboard.html
+++ b/server/auvsi_suas/static/auvsi_suas/pages/mission-dashboard/mission-dashboard.html
@@ -38,10 +38,8 @@
 
     <hr></hr>
 
-    <div class="row" ng-repeat="team in missionDashboardCtrl.getTeamsToDisplay()">
-        <team-status team="team"
-                     telemetry="missionDashboardCtrl.getTelemetry(team)">
-        </team-status>
+    <div class="row" ng-repeat="team in missionDashboardCtrl.teams">
+        <team-status team="team"></team-status>
     </div>
   </div>
 

--- a/server/auvsi_suas/views/teams.py
+++ b/server/auvsi_suas/views/teams.py
@@ -14,13 +14,14 @@ from django.views.generic import View
 
 def user_json(user):
     """Generate JSON-style dict for user."""
+    telemetry = UasTelemetry.last_for_user(user)
     return {
         'name': user.username,
         'id': user.pk,
         'on_clock': MissionClockEvent.user_on_clock(user),
         'on_timeout': MissionClockEvent.user_on_timeout(user),
         'in_air': TakeoffOrLandingEvent.user_in_air(user),
-        'active': UasTelemetry.user_active(user),
+        'telemetry': telemetry.json() if telemetry else None
     }
 
 


### PR DESCRIPTION
Returning telemetry in the teams request makes fewer requests and
database queries.

Indexing (user,timestamp) should allow simultaneous user filtering,
timestamp filtering, and ordering by timestamp via the index without
having to post-filter and post-sort. This should make requests more
efficient.

Fixes #164 