### PR TITLE
Add admin endpoint to edit mission waypoints

### DIFF
--- a/server/auvsi_suas/views/missions.py
+++ b/server/auvsi_suas/views/missions.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from auvsi_suas.models import MissionConfig
+from auvsi_suas.models import MissionConfig, GpsPosition, AerialPosition, Waypoint
 from auvsi_suas.views import logger
 from auvsi_suas.views.decorators import require_login
 from auvsi_suas.views.decorators import require_superuser

--- a/server/auvsi_suas/views/missions.py
+++ b/server/auvsi_suas/views/missions.py
@@ -12,7 +12,6 @@ from django.http import HttpResponse
 from django.http import HttpResponseBadRequest
 from django.http import HttpResponseNotFound
 from django.http import HttpResponseServerError
-from django.http import JsonResponse
 from django.utils.decorators import method_decorator
 from django.views.generic import View
 
@@ -77,6 +76,48 @@ def mission_for_request(request_params):
     # Mission not specified, get the single active mission.
     return active_mission()
 
+class MissionSetWaypoints(View):
+
+    @method_decorator(require_superuser)
+    def post(self, request):
+        try:
+            sent_json = json.loads(request.body)
+        except ValueError:
+            return HttpResponseBadRequest('Body is not a valid json')
+
+        try:
+            pk = sent_json['pk']
+            waypoints = sent_json['waypoints']
+            assert type(pk) == int
+            assert type(waypoints) == list
+            assert all(type(w) == dict and 'latitude' in w and 'longitude' in w and 'altitude_msl' in w for w in waypoints)
+        except (KeyError, AssertionError):
+            return HttpResponseBadRequest('JSON does not contain properly formatted fields')
+
+        try:
+            mission = MissionConfig.objects.get(pk=pk)
+        except MissionConfig.DoesNotExist:
+            return HttpResponseNotFound('Mission %s not found.' % pk)
+
+        waypoints_objects = []
+        for i, waypoint in enumerate(waypoints):
+            gps_position = GpsPosition.objects.create(
+                latitude=waypoint['latitude'],
+                longitude=waypoint['longitude'])
+
+            aerial_position = AerialPosition.objects.create(
+                gps_position=gps_position,
+                altitude_msl=waypoint['altitude_msl'])
+
+            new_wp_object = Waypoint.objects.create(
+                position=aerial_position,
+                order=(i+1))
+
+            waypoints_objects.append(new_wp_object)
+
+        mission.mission_waypoints = waypoints_objects
+        mission.save()
+        return HttpResponse("Successfully changed mission waypoints")
 
 class Missions(View):
     """Handles requests for all missions."""
@@ -91,9 +132,7 @@ class Missions(View):
         for mission in missions:
             out.append(mission.json(request.user.is_superuser))
 
-        # Older versions of JS allow hijacking the Array constructor to steal
-        # JSON data. It is not a problem in recent versions.
-        return JsonResponse(out, safe=False)
+        return HttpResponse(json.dumps(out), content_type="application/json")
 
 
 class MissionsId(View):

--- a/server/auvsi_suas/views/missions.py
+++ b/server/auvsi_suas/views/missions.py
@@ -77,6 +77,48 @@ def mission_for_request(request_params):
     # Mission not specified, get the single active mission.
     return active_mission()
 
+class MissionSetWaypoints(View):
+
+    @method_decorator(require_superuser)
+    def post(self, request):
+        try:
+            sent_json = json.loads(request.body)
+        except ValueError:
+            return HttpResponseBadRequest('Body is not a valid json')
+
+        try:
+            pk = sent_json['pk']
+            waypoints = sent_json['waypoints']
+            assert type(pk) == int
+            assert type(waypoints) == list
+            assert all(type(w) == dict and 'latitude' in w and 'longitude' in w and 'altitude_msl' in w for w in waypoints)
+        except (KeyError, AssertionError):
+            return HttpResponseBadRequest('JSON does not contain properly formatted fields')
+
+        try:
+            mission = MissionConfig.objects.get(pk=pk)
+        except MissionConfig.DoesNotExist:
+            return HttpResponseNotFound('Mission %s not found.' % pk)
+
+        waypoints_objects = []
+        for i, waypoint in enumerate(waypoints):
+            gps_position = GpsPosition.objects.create(
+                latitude=waypoint['latitude'],
+                longitude=waypoint['longitude'])
+
+            aerial_position = AerialPosition.objects.create(
+                gps_position=gps_position,
+                altitude_msl=waypoint['altitude_msl'])
+
+            new_wp_object = Waypoint.objects.create(
+                position=aerial_position,
+                order=(i+1))
+
+            waypoints_objects.append(new_wp_object)
+
+        mission.mission_waypoints = waypoints_objects
+        mission.save()
+        return HttpResponse("Successfully changed mission waypoints")
 
 class Missions(View):
     """Handles requests for all missions."""

--- a/server/auvsi_suas/views/missions.py
+++ b/server/auvsi_suas/views/missions.py
@@ -99,7 +99,15 @@ class MissionSetWaypoints(View):
                 'JSON does not contain properly formatted fields')
 
         try:
-            mission = MissionConfig.objects.get(pk=pk)
+            # if the pk is 0, edit the currently active mission
+            if pk == 0:
+                active = active_mission()
+                if active[0] == None:
+                    return active[1]
+                else:
+                    mission = active[0]
+            else:
+                mission = MissionConfig.objects.get(pk=pk)
         except MissionConfig.DoesNotExist:
             return HttpResponseNotFound('Mission %s not found.' % pk)
 

--- a/server/auvsi_suas/views/missions.py
+++ b/server/auvsi_suas/views/missions.py
@@ -77,8 +77,8 @@ def mission_for_request(request_params):
     # Mission not specified, get the single active mission.
     return active_mission()
 
-class MissionSetWaypoints(View):
 
+class MissionSetWaypoints(View):
     @method_decorator(require_superuser)
     def post(self, request):
         try:
@@ -91,9 +91,11 @@ class MissionSetWaypoints(View):
             waypoints = sent_json['waypoints']
             assert type(pk) == int
             assert type(waypoints) == list
-            assert all(type(w) == dict and 'latitude' in w and 'longitude' in w and 'altitude_msl' in w for w in waypoints)
+            assert all(type(w) == dict and 'latitude' in w and 'longitude' in w
+                       and 'altitude_msl' in w for w in waypoints)
         except (KeyError, AssertionError):
-            return HttpResponseBadRequest('JSON does not contain properly formatted fields')
+            return HttpResponseBadRequest(
+                'JSON does not contain properly formatted fields')
 
         try:
             mission = MissionConfig.objects.get(pk=pk)
@@ -110,15 +112,15 @@ class MissionSetWaypoints(View):
                 gps_position=gps_position,
                 altitude_msl=waypoint['altitude_msl'])
 
-            new_wp_object = Waypoint.objects.create(
-                position=aerial_position,
-                order=(i+1))
+            new_wp_object = Waypoint.objects.create(position=aerial_position,
+                                                    order=(i + 1))
 
             waypoints_objects.append(new_wp_object)
 
         mission.mission_waypoints = waypoints_objects
         mission.save()
         return HttpResponse("Successfully changed mission waypoints")
+
 
 class Missions(View):
     """Handles requests for all missions."""

--- a/server/auvsi_suas/views/missions.py
+++ b/server/auvsi_suas/views/missions.py
@@ -91,8 +91,9 @@ class MissionSetWaypoints(View):
             waypoints = sent_json['waypoints']
             assert type(pk) == int
             assert type(waypoints) == list
-            assert all(type(w) == dict and 'latitude' in w and 'longitude' in w
-                       and 'altitude_msl' in w for w in waypoints)
+            assert all(type(w) == dict and 'latitude' in w and
+                       'longitude' in w and 'altitude_msl' in w
+                       for w in waypoints)
         except (KeyError, AssertionError):
             return HttpResponseBadRequest(
                 'JSON does not contain properly formatted fields')

--- a/server/auvsi_suas/views/urls.py
+++ b/server/auvsi_suas/views/urls.py
@@ -1,11 +1,12 @@
 from auvsi_suas.views.clear_cache import ClearCache
 from auvsi_suas.views.login import Login
-from auvsi_suas.views.missions import Missions, MissionsId, MissionSetWaypoints
+from auvsi_suas.views.missions import Missions, MissionsId
 from auvsi_suas.views.obstacles import Obstacles
 from auvsi_suas.views.targets import Targets, TargetsId, TargetsIdImage, TargetsAdminReview
 from auvsi_suas.views.teams import Teams, TeamsId
 from auvsi_suas.views.telemetry import Telemetry
-from auvsi_suas.views.auvsi_admin.evaluate_teams import EvaluateTeams
+from auvsi_suas.views.auvsi_admin.evaluate_teams import EvaluateTeamsCsv
+from auvsi_suas.views.auvsi_admin.evaluate_teams import EvaluateTeamsJson
 from auvsi_suas.views.auvsi_admin.export_kml import ExportKml
 from auvsi_suas.views.auvsi_admin.index import Index
 from auvsi_suas.views.auvsi_admin.live_kml import LiveKml, LiveKmlUpdate
@@ -27,7 +28,6 @@ urlpatterns = patterns(
         name='targets_id_image'),
     # Admin API
     url(r'^api/missions$', Missions.as_view(), name='missions'),
-    url(r'^api/missions/set_waypoints$', MissionSetWaypoints.as_view(), name='mission_add'),
     url(r'^api/missions/(?P<pk>\d+)$', MissionsId.as_view(), name='missions_id'),
     url(r'^api/targets/review$', TargetsAdminReview.as_view(),
         name='targets_review'),
@@ -38,12 +38,14 @@ urlpatterns = patterns(
     url(r'^api/clear_cache$', ClearCache.as_view(), name='clear_cache'),
     # Admin access views
     url(r'^$', Index.as_view(), name='index'),
-    url(r'^auvsi_admin/evaluate_teams.csv$', EvaluateTeams.as_view(),
+    url(r'^auvsi_admin/evaluate_teams$', EvaluateTeamsJson.as_view(),
         name='evaluate_teams'),
-    url(r'^auvsi_admin/export_data.kml$', ExportKml.as_view(),
+    url(r'^auvsi_admin/evaluate_teams\.csv$',
+        EvaluateTeamsCsv.as_view(), name='evaluate_teams_csv'),
+    url(r'^auvsi_admin/export_data\.kml$', ExportKml.as_view(),
         name='export_data'),
-    url(r'^auvsi_admin/live.kml$', LiveKml.as_view(), name='live_kml'),
-    url(r'^auvsi_admin/update.kml$', LiveKmlUpdate.as_view(),
+    url(r'^auvsi_admin/live\.kml$', LiveKml.as_view(), name='live_kml'),
+    url(r'^auvsi_admin/update\.kml$', LiveKmlUpdate.as_view(),
         name='update_kml'),
 ) + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 # yapf: enable

--- a/server/auvsi_suas/views/urls.py
+++ b/server/auvsi_suas/views/urls.py
@@ -1,6 +1,6 @@
 from auvsi_suas.views.clear_cache import ClearCache
 from auvsi_suas.views.login import Login
-from auvsi_suas.views.missions import Missions, MissionsId
+from auvsi_suas.views.missions import Missions, MissionsId, MissionSetWaypoints
 from auvsi_suas.views.obstacles import Obstacles
 from auvsi_suas.views.targets import Targets, TargetsId, TargetsIdImage, TargetsAdminReview
 from auvsi_suas.views.teams import Teams, TeamsId
@@ -28,6 +28,7 @@ urlpatterns = patterns(
         name='targets_id_image'),
     # Admin API
     url(r'^api/missions$', Missions.as_view(), name='missions'),
+    url(r'^api/missions/set_waypoints$', MissionSetWaypoints.as_view(), name='mission_add'),
     url(r'^api/missions/(?P<pk>\d+)$', MissionsId.as_view(), name='missions_id'),
     url(r'^api/targets/review$', TargetsAdminReview.as_view(),
         name='targets_review'),

--- a/server/auvsi_suas/views/urls.py
+++ b/server/auvsi_suas/views/urls.py
@@ -1,12 +1,11 @@
 from auvsi_suas.views.clear_cache import ClearCache
 from auvsi_suas.views.login import Login
-from auvsi_suas.views.missions import Missions, MissionsId
+from auvsi_suas.views.missions import Missions, MissionsId, MissionSetWaypoints
 from auvsi_suas.views.obstacles import Obstacles
 from auvsi_suas.views.targets import Targets, TargetsId, TargetsIdImage, TargetsAdminReview
 from auvsi_suas.views.teams import Teams, TeamsId
 from auvsi_suas.views.telemetry import Telemetry
-from auvsi_suas.views.auvsi_admin.evaluate_teams import EvaluateTeamsCsv
-from auvsi_suas.views.auvsi_admin.evaluate_teams import EvaluateTeamsJson
+from auvsi_suas.views.auvsi_admin.evaluate_teams import EvaluateTeams
 from auvsi_suas.views.auvsi_admin.export_kml import ExportKml
 from auvsi_suas.views.auvsi_admin.index import Index
 from auvsi_suas.views.auvsi_admin.live_kml import LiveKml, LiveKmlUpdate
@@ -28,6 +27,7 @@ urlpatterns = patterns(
         name='targets_id_image'),
     # Admin API
     url(r'^api/missions$', Missions.as_view(), name='missions'),
+    url(r'^api/missions/set_waypoints$', MissionSetWaypoints.as_view(), name='mission_add'),
     url(r'^api/missions/(?P<pk>\d+)$', MissionsId.as_view(), name='missions_id'),
     url(r'^api/targets/review$', TargetsAdminReview.as_view(),
         name='targets_review'),
@@ -38,14 +38,12 @@ urlpatterns = patterns(
     url(r'^api/clear_cache$', ClearCache.as_view(), name='clear_cache'),
     # Admin access views
     url(r'^$', Index.as_view(), name='index'),
-    url(r'^auvsi_admin/evaluate_teams$', EvaluateTeamsJson.as_view(),
+    url(r'^auvsi_admin/evaluate_teams.csv$', EvaluateTeams.as_view(),
         name='evaluate_teams'),
-    url(r'^auvsi_admin/evaluate_teams\.csv$',
-        EvaluateTeamsCsv.as_view(), name='evaluate_teams_csv'),
-    url(r'^auvsi_admin/export_data\.kml$', ExportKml.as_view(),
+    url(r'^auvsi_admin/export_data.kml$', ExportKml.as_view(),
         name='export_data'),
-    url(r'^auvsi_admin/live\.kml$', LiveKml.as_view(), name='live_kml'),
-    url(r'^auvsi_admin/update\.kml$', LiveKmlUpdate.as_view(),
+    url(r'^auvsi_admin/live.kml$', LiveKml.as_view(), name='live_kml'),
+    url(r'^auvsi_admin/update.kml$', LiveKmlUpdate.as_view(),
         name='update_kml'),
 ) + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 # yapf: enable


### PR DESCRIPTION
CUAir always spends a lot of time at test flights copying over our mission waypoints into the interop server when we want to use it, so I added an admin endpoint that accepts a JSON to edit the mission waypoints of a particular mission. This will save valuable time at test flights and hopefully other teams will find being able to automate transferring waypoints from a ground station to the interop server useful as well.

I added a new class to the missions.py file with a POST superuser endpoint that accepts a JSON in the form {"pk":PK, "waypoints":[]}. This creates new GpsPosition, AerialPosition, and Waypoint objects then changes the list of waypoints in the selected mission pk to be the waypoints sent.

I'm happy to add documentation for this change as well in the docs.