### PR TITLE
Update target scoring

### DIFF
--- a/server/auvsi_suas/fixtures/testdata/sample_mission.json
+++ b/server/auvsi_suas/fixtures/testdata/sample_mission.json
@@ -711,7 +711,7 @@
         "shape": 5,
         "location": 337,
         "last_modified_time": "1970-01-01T00:00:00.500Z",
-        "autonomous": false,
+        "autonomous": true,
         "background_color": 2,
         "thumbnail": "",
         "user": 53

--- a/server/auvsi_suas/models/mission_config.py
+++ b/server/auvsi_suas/models/mission_config.py
@@ -292,8 +292,7 @@ class MissionConfig(models.Model):
             user_targets = Target.objects.filter(user=user).all()
             target_sets = {
                 'manual': [t for t in user_targets if not t.autonomous],
-                'auto': [t for t in user_targets
-                         if t.autonomous][:settings.TARGET_MAX_NUM_AUTONOMOUS],
+                'auto': [t for t in user_targets if t.autonomous],
             }
             for target_set, targets in target_sets.iteritems():
                 evaluator = TargetEvaluator(targets, self.targets.all())

--- a/server/auvsi_suas/models/mission_config_test.py
+++ b/server/auvsi_suas/models/mission_config_test.py
@@ -251,17 +251,25 @@ class TestMissionConfigModelSampleMission(TestCase):
         self.assertAlmostEqual(0.5, teams[user0]['uas_telem_times']['max'])
         self.assertAlmostEqual(1. / 6, teams[user0]['uas_telem_times']['avg'])
 
-        self.assertEqual(
-            11, teams[user0]['targets']['manual']['matched_target_value'])
+        self.assertAlmostEqual(
+            0.28,
+            teams[user0]['targets']['manual']['matched_target_value'],
+            places=3)
         self.assertEqual(
             1, teams[user0]['targets']['manual']['unmatched_target_count'])
+
+        self.assertAlmostEqual(
+            1,
+            teams[user0]['targets']['auto']['matched_target_value'],
+            places=3)
+        self.assertEqual(
+            0, teams[user0]['targets']['auto']['unmatched_target_count'])
+
         # Real targets are PKs 1, 2, and 3.
         self.assertEqual(
-            'objective',
-            teams[user0]['targets']['manual']['targets'][1]['actionable'])
+            0.0, teams[user0]['targets']['manual']['targets'][1]['actionable'])
         self.assertEqual(
-            None,
-            teams[user0]['targets']['manual']['targets'][2]['actionable'])
+            1.0, teams[user0]['targets']['auto']['targets'][1]['actionable'])
 
         self.assertEqual(True, teams[user0]['stationary_obst_collision'][25])
         self.assertEqual(False, teams[user0]['stationary_obst_collision'][26])

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -205,45 +205,20 @@ SATISFIED_WAYPOINT_DIST_MAX_FT = 50
 # The max distance for a UAS to diverge from the waypoint track.
 WAYPOINT_TRACK_DIST_MAX_FT = 100
 
-# The max number of autonomous targets.
-TARGET_MAX_NUM_AUTONOMOUS = 6
+# The lowest allowed location accuracy (in feet)
+TARGET_LOCATION_THRESHOLD = 150
 
-# The target classification match values: [start, end) -> value
-TARGET_CLASSIFY_RANGES = [
-    {"start": float("-inf"),
-     "end": 2. / 5,
-     "value": 0},
-    {"start": 2. / 5,
-     "end": 1,
-     "value": 1},
-    {"start": 1,
-     "end": float("inf"),
-     "value": 2},
-]
+# The weight of geolocation accuracy when calculating a target match score.
+GEOLOCATION_WEIGHT = 0.2
 
-# The location accuracy match values: (start, end] -> value
-TARGET_LOCATION_RANGES = [
-    {"start": float("-inf"),
-     "end": 75,
-     "value": 4},
-    {"start": 75,
-     "end": 150,
-     "value": 2},
-    {"start": 150,
-     "end": float("inf"),
-     "value": 0},
-]
+# The weight of classification accuracy when calculating a target match score.
+CHARACTERISTICS_WEIGHT = 0.2
 
-# Actionable Intelligence threshold and objective level parameters.
-TARGET_ACTIONABLE_PARAMS = {
-    "threshold": {
-        "characteristics": 3. / 5.,
-        "location": 150,  # ft
-        "value": 1,
-    },
-    "objective": {
-        "characteristics": 5. / 5.,
-        "location": 75,  # ft
-        "value": 2,
-    },
-}
+# The weight of actionable intelligence when calculating a target match score.
+ACTIONABLE_WEIGHT = 0.1
+
+# The weight of submission over interop when calculating a target match score.
+INTEROPERABILITY_WEIGHT = 0.3
+
+# The weight of autonomy when calculating a target match score.
+AUTONOMY_WEIGHT = 0.2


### PR DESCRIPTION
* Update match_value function to take into account new scoring scheme
* Update location scoring to be linear
* Update classification scoring 
* Update actionable scoring such that target is only actionable if it is submitted during first flight. Remove classification/location requirements for actionable targets
* Add `interop_submission` field to target to keep track of whether the target was submitted via the interop system. A target is marked as being submitted via the interop system if it is uploaded/updated while the team is still on mission clock. (Any targets uploaded/updated after then are probably a judge uploading from USB submission)
* Change weighting of location, classification and actionable scores. Take into account interop score and autonomy score when calculating match value
* Remove the max 6 autonomous targets restriction
* Update tests

**Note:** There are two rule changes that are not reflected in this PR: (1) counting only the higher-scoring object if both the autonomously and manually submitted objects match the same real target and (2) the extra object penalty. Looking at the output from evaluate_teams, it seems as though these changes should be implemented in the auto-scoring system that we will eventually write. 

**Still TODO:** We need to provide an admin flag to the interop_cli to mark whether the upload is actionable, and accept such in the view code for admins only. We need this to upload USB submissions that were actionable.