### PR TITLE
Add a team_id field to targets POST

### DIFF
--- a/client/interop/types.py
+++ b/client/interop/types.py
@@ -45,7 +45,7 @@ class ClientBaseType(object):
                 serial[attr] = data.serialize()
             elif isinstance(data, list):
                 serial[attr] = [d.serialize() for d in data]
-            else:
+            elif data is not None:
                 serial[attr] = data
         return serial
 
@@ -252,6 +252,8 @@ class Target(ClientBaseType):
             certain target types.
         autonomous: Optional; defaults to False. Indicates that this is an
             ADLC target.
+        team_id: Optional. The username of the team on whose behalf to submit
+            targets. Must be admin user to specify.
 
     Raises:
         ValueError: Argument not valid.
@@ -259,7 +261,7 @@ class Target(ClientBaseType):
 
     attrs = ['id', 'user', 'type', 'latitude', 'longitude', 'orientation',
              'shape', 'background_color', 'alphanumeric', 'alphanumeric_color',
-             'description', 'autonomous']
+             'description', 'autonomous', 'team_id']
 
     def __init__(self,
                  id=None,
@@ -273,7 +275,8 @@ class Target(ClientBaseType):
                  alphanumeric=None,
                  alphanumeric_color=None,
                  description=None,
-                 autonomous=False):
+                 autonomous=False,
+                 team_id=None):
         self.id = id
         self.user = user
         self.type = type
@@ -286,3 +289,4 @@ class Target(ClientBaseType):
         self.alphanumeric_color = alphanumeric_color
         self.description = description
         self.autonomous = autonomous
+        self.team_id = team_id

--- a/client/interop/types_test.py
+++ b/client/interop/types_test.py
@@ -383,7 +383,8 @@ class TestTarget(unittest.TestCase):
                    background_color='white',
                    alphanumeric='a',
                    alphanumeric_color='black',
-                   autonomous=True)
+                   autonomous=True,
+                   team_id='testuser')
         s = o.serialize()
 
         self.assertEqual(12, len(s))
@@ -398,6 +399,7 @@ class TestTarget(unittest.TestCase):
         self.assertEqual('a', s['alphanumeric'])
         self.assertEqual('black', s['alphanumeric_color'])
         self.assertEqual(True, s['autonomous'])
+        self.assertEqual('testuser', s['team_id'])
 
     def test_deserialize(self):
         """Test deserialization."""
@@ -411,6 +413,7 @@ class TestTarget(unittest.TestCase):
             'alphanumeric': 'a',
             'alphanumeric_color': 'black',
             'autonomous': True,
+            'team_id': 'testuser'
         })
 
         self.assertEqual('standard', o.type)
@@ -422,6 +425,7 @@ class TestTarget(unittest.TestCase):
         self.assertEqual('a', o.alphanumeric)
         self.assertEqual('black', o.alphanumeric_color)
         self.assertEqual(True, o.autonomous)
+        self.assertEqual('testuser', o.team_id)
 
         o = Target.deserialize({'type': 'emergent'})
 

--- a/client/tools/interop_cli.py
+++ b/client/tools/interop_cli.py
@@ -30,7 +30,7 @@ def targets(args, client):
             raise ValueError('--target_dir is required.')
         upload_legacy_targets(client, args.legacy_filepath, args.target_dir)
     elif args.target_dir:
-        upload_targets(client, args.target_dir)
+        upload_targets(client, args.target_dir, args.team_id)
     else:
         targets = client.get_targets()
         for target in targets:
@@ -73,6 +73,7 @@ def main():
                         required=True,
                         help='Username for interoperability.')
     parser.add_argument('--password', help='Password for interoperability.')
+
     subparsers = parser.add_subparsers(help='Sub-command help.')
 
     subparser = subparsers.add_parser('missions', help='Get missions.')
@@ -107,6 +108,10 @@ unique targets, if the tool is run multiple times.''',
     subparser.add_argument(
         '--target_dir',
         help='Enables target upload. Directory containing target data.')
+    subparser.add_argument(
+        '--team_id',
+        help='''The username of the team on whose behalf to submit targets.
+Must be admin user to specify''')
 
     subparser = subparsers.add_parser('probe', help='Send dummy requests.')
     subparser.set_defaults(func=probe)

--- a/client/tools/upload_targets.py
+++ b/client/tools/upload_targets.py
@@ -132,7 +132,7 @@ def upload_legacy_targets(client, target_filepath, imagery_dir):
         client.put_target_image(target.id, image_data)
 
 
-def upload_target(client, target_file, image_file):
+def upload_target(client, target_file, image_file, team_id=None):
     """Upload a single target to the server
 
     Args:
@@ -140,10 +140,13 @@ def upload_target(client, target_file, image_file):
         target_file: Path to file containing target details in the Object
             File Format.
         image_file: Path to target thumbnail. May be None.
+        team_id: The username of the team on whose behalf to submit targets.
+            Defaults to None.
     """
     with open(target_file) as f:
         target = Target.deserialize(json.load(f))
 
+    target.team_id = team_id
     logger.info('Uploading target %s: %r' % (target_file, target))
     target = client.post_target(target)
     if image_file:
@@ -154,13 +157,15 @@ def upload_target(client, target_file, image_file):
         logger.warning('No thumbnail for target %s' % target_file)
 
 
-def upload_targets(client, target_dir):
+def upload_targets(client, target_dir, team_id=None):
     """Upload all targets found in directory
 
     Args:
         client: interop.Client connected to the server
         target_dir: Path to directory containing target files in the Object
             File Format and target thumbnails.
+        team_id: The username of the team on whose behalf to submit targets.
+            Defaults to None.
     """
     targets = {}
     images = {}
@@ -191,4 +196,4 @@ def upload_targets(client, target_dir):
     logger.info('Found target-image pairs: %s' % pairs)
 
     for target, image in pairs.items():
-        upload_target(client, target, image)
+        upload_target(client, target, image, team_id)

--- a/server/auvsi_suas/views/targets.py
+++ b/server/auvsi_suas/views/targets.py
@@ -145,6 +145,15 @@ class Targets(View):
         if 'type' not in data:
             return HttpResponseBadRequest('Target type required.')
 
+        # Team id can only be specified if superuser.
+        user = request.user
+        if 'team_id' in data:
+            if request.user.is_superuser:
+                user = User.objects.get(username=data['team_id'])
+            else:
+                return HttpResponseForbidden(
+                    'Non-admin users cannot send team_id')
+
         latitude = data.get('latitude')
         longitude = data.get('longitude')
 
@@ -166,7 +175,7 @@ class Targets(View):
             l.save()
 
         # Use the dictionary get() method to default non-existent values to None.
-        t = Target(user=request.user,
+        t = Target(user=user,
                    target_type=data['type'],
                    location=l,
                    orientation=data.get('orientation'),


### PR DESCRIPTION
It will allow an admin user to create a target on behalf of a team. This change is a prereq to adding an `actionable_override` flag.