### PR TITLE
Add urllib3+requests to tools requirements for docs build.

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,7 +1,10 @@
 -r ../client/requirements.txt
 -r ../server/requirements.txt
+pyOpenSSL
+requests
 simplekml==1.2.7
 sphinx>=1.3
 sphinx_rtd_theme
 sphinxcontrib-httpdomain>=1.3
+urllib3
 yapf==0.6.2

--- a/tools/setup_tools.sh
+++ b/tools/setup_tools.sh
@@ -21,4 +21,4 @@ apt-get -qq install -y \
 log "Building tools virtualenv."
 (cd ${REPO}/tools && \
     virtualenv -p /usr/bin/python2 venv && \
-    pip install -r requirements.txt)
+    pip install -U -r requirements.txt)


### PR DESCRIPTION
Appears that urllib3+requests has become a new dependency as builds have been
failing with:
Could not import extension sphinx.builders.linkcheck (exception: No
module named packages.urllib3.exceptions)