### PR TITLE
Set default logging to INFO. Sleep before client test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
   # Test server & client.
   - ./server/run.sh
   - ./server/test.sh
+  - sleep 10  # Sleep to allow server to start.
   - ./client/test.sh
   # Verify that docs build.
   - ./tools/build_docs.sh

--- a/client/tools/interop_cli.py
+++ b/client/tools/interop_cli.py
@@ -66,7 +66,7 @@ def mavlink(args, client):
 def main():
     # Setup logging
     logging.basicConfig(
-        level=logging.DEBUG,
+        level=logging.INFO,
         stream=sys.stdout,
         format='%(asctime)s: %(name)s: %(levelname)s: %(message)s')
 


### PR DESCRIPTION
For high-rate telemetry forwarding, we don't want to print urllib debug messages.

Sleeping will reduce flakiness of client test and spurious build errors.