### PR TITLE
Add healthcheck to container, poll in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ install:
   - ./client/build.sh
 
 script:
-  # Test server & client.
-  - ./server/run.sh
+  # Test server.
   - ./server/test.sh
-  - sleep 10  # Sleep to allow server to start.
+  - ./server/run.sh
+  # Test client.
   - ./client/test.sh
   # Verify that docs build.
   - ./tools/build_docs.sh

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /interop/server
 RUN sudo apt-get -qq update && sudo apt-get -qq install -y \
         apache2 \
         apache2-utils \
+        curl \
         libapache2-mod-auth-pgsql \
         libapache2-mod-auth-plain \
         libapache2-mod-python \
@@ -67,3 +68,6 @@ CMD sudo service postgresql start && \
   sudo service memcached start && \
   sudo service apache2 start && \
   tail -f /dev/null
+
+HEALTHCHECK --interval=10s --timeout=3s \
+    CMD curl -f http://localhost/ || exit 1

--- a/server/run.sh
+++ b/server/run.sh
@@ -2,3 +2,11 @@
 # Runs the Interop Server in a container.
 
 docker run -d --restart=unless-stopped --interactive --tty --publish 8000:80 --name interop-server auvsisuas/interop-server
+
+# Poll server up to 2 min for healthiness before proceeding.
+for i in {1..120};
+do
+    docker inspect -f "{{.State.Health.Status}}" interop-server | grep healthy && exit 0 || sleep 1;
+done
+
+exit 1


### PR DESCRIPTION
Purpose is to decrease sporatic CI test failures because the client
tests start before the server is ready. Secondary benefit to increase
health status visibility via a secondary prober.

Healthcheck which will probe the Docker container to validate that the
server is healthy. It simply polls the homepage (/) using curl. It
stores the status and any errors, and can be queried using `docker
inspect`. Format is defined here:
https://docs.docker.com/engine/reference/builder/#/healthcheck