### PR TITLE
Refactor evaluation data into object.

### DIFF
--- a/server/auvsi_suas/models/fly_zone.py
+++ b/server/auvsi_suas/models/fly_zone.py
@@ -1,4 +1,5 @@
 """Fly zone model."""
+import datetime
 import numpy as np
 from django.conf import settings
 from django.db import models
@@ -101,8 +102,8 @@ class FlyZone(models.Model):
                 which demonstrate the flight of the UAS.
         Returns:
             num_violations: The number of times fly zone boundaries violated.
-            total_time: The floating point total time in seconds spent out of
-                bounds as indicated by the telemetry logs.
+            total_time: The timedelta for time spent out of bounds
+                as indicated by the telemetry logs.
         """
         # Get the aerial positions for the logs
         aerial_pos_list = [cur_log.uas_position
@@ -124,7 +125,7 @@ class FlyZone(models.Model):
                                   for cur_id in range(len(log_ids_to_process))
                                   if not satisfied_positions[cur_id]]
 
-        out_of_bounds_time = 0
+        out_of_bounds_time = datetime.timedelta()
         violations = 0
         prev_event_id = -1
         currently_in_bounds = True
@@ -148,7 +149,7 @@ class FlyZone(models.Model):
             if not currently_in_bounds and i > 0:
                 time_diff = (uas_telemetry_logs[i].timestamp -
                              uas_telemetry_logs[i - 1].timestamp)
-                out_of_bounds_time += time_diff.total_seconds()
+                out_of_bounds_time += time_diff
 
         return (violations, out_of_bounds_time)
 

--- a/server/auvsi_suas/models/fly_zone_test.py
+++ b/server/auvsi_suas/models/fly_zone_test.py
@@ -320,4 +320,5 @@ class TestFlyZone(TestCase):
             num_violations, out_of_bounds_time = \
                 FlyZone.out_of_bounds(zones, uas_logs)
             self.assertEqual(num_violations, exp_violations)
-            self.assertAlmostEqual(out_of_bounds_time, exp_out_of_bounds_time)
+            self.assertAlmostEqual(out_of_bounds_time.total_seconds(),
+                                   exp_out_of_bounds_time)

--- a/server/auvsi_suas/views/auvsi_admin/evaluate_teams_test.py
+++ b/server/auvsi_suas/views/auvsi_admin/evaluate_teams_test.py
@@ -55,7 +55,7 @@ class TestEvaluateTeams(TestCase):
         self.assertEqual(len(data), 3)
         self.assertIn('user0', data)
         self.assertIn('user1', data)
-        self.assertIn('uas_telem_times', data['user0'])
+        self.assertIn('uas_telemetry_time_max', data['user0'])
 
     def test_evaluate_teams_specific_team(self):
         """Tests the eval Json method on a specific team."""
@@ -76,7 +76,7 @@ class TestEvaluateTeams(TestCase):
         self.assertEqual(response.status_code, 200)
         csv_data = response.content
         self.assertEqual(len(csv_data.split('\n')), 5)
-        self.assertIn('username', csv_data)
-        self.assertIn('uas_telem_times.max', csv_data)
+        self.assertIn('team', csv_data)
+        self.assertIn('uas_telemetry_time_max', csv_data)
         self.assertIn('user0', csv_data)
         self.assertIn('user1', csv_data)


### PR DESCRIPTION
This is in prep for adding more evaluation data that will be exported
(e.g. total mission score), and for a more complex export which will
include json (post-analysis), csv (downstream scoring), and tex (team
feedback).

For #218 