### PR TITLE
Return csv/json team evaluations as single zip.

### DIFF
--- a/server/auvsi_suas/static/auvsi_suas/pages/evaluate-teams/evaluate-teams-controller.js
+++ b/server/auvsi_suas/static/auvsi_suas/pages/evaluate-teams/evaluate-teams-controller.js
@@ -24,11 +24,6 @@ EvaluateTeamsCtrl = function($window, Backend) {
     this.selectedTeamId = "-1";
 
     /**
-     * @export {!string} The extension for export.
-     */
-    this.selectedExtension = 'Json';
-
-    /**
      * @private @const {!angular.$window} The window service.
      */
     this.window_ = $window;
@@ -51,14 +46,8 @@ EvaluateTeamsCtrl.prototype.evaluate = function() {
         query = '?team=' + id;
     }
 
-    // Determine extension from selected.
-    var ext = '';
-    if (this.selectedExtension == 'Csv') {
-        ext = '.csv';
-    }
-
     // Open evaluation in new tab.
-    this.window_.open('/auvsi_admin/evaluate_teams' + ext + query, '_blank');
+    this.window_.open('/auvsi_admin/evaluate_teams.zip'+ query, '_blank');
 };
 
 

--- a/server/auvsi_suas/static/auvsi_suas/pages/evaluate-teams/evaluate-teams-controller_test.js
+++ b/server/auvsi_suas/static/auvsi_suas/pages/evaluate-teams/evaluate-teams-controller_test.js
@@ -37,8 +37,7 @@ describe("EvaluateTeamsCtrl controller", function() {
     it("Should get evaluate teams", function() {
         httpBackend.flush();
         evaluateTeamsCtrl.selectedTeamId = '1';
-        evaluateTeamsCtrl.selectedExtension = 'Csv';
-        window.expectUrl = '/auvsi_admin/evaluate_teams.csv?team=1';
+        window.expectUrl = '/auvsi_admin/evaluate_teams.zip?team=1';
         evaluateTeamsCtrl.evaluate();
     });
 });

--- a/server/auvsi_suas/static/auvsi_suas/pages/evaluate-teams/evaluate-teams.html
+++ b/server/auvsi_suas/static/auvsi_suas/pages/evaluate-teams/evaluate-teams.html
@@ -16,15 +16,6 @@
     </div>
 
     <div class="row">
-        <label>Format
-            <select ng-model="evaluateTeamsCtrl.selectedExtension">
-                <option value="Json">Json</option>
-                <option value="Csv">Csv</option>
-            </select>
-        </label>
-    </div>
-
-    <div class="row">
         <button type="button" class="success button" ng-click="evaluateTeamsCtrl.evaluate()">Evaluate</button>
     </div>
   </div>

--- a/server/auvsi_suas/views/urls.py
+++ b/server/auvsi_suas/views/urls.py
@@ -5,8 +5,7 @@ from auvsi_suas.views.obstacles import Obstacles
 from auvsi_suas.views.targets import Targets, TargetsId, TargetsIdImage, TargetsAdminReview
 from auvsi_suas.views.teams import Teams, TeamsId
 from auvsi_suas.views.telemetry import Telemetry
-from auvsi_suas.views.auvsi_admin.evaluate_teams import EvaluateTeamsCsv
-from auvsi_suas.views.auvsi_admin.evaluate_teams import EvaluateTeamsJson
+from auvsi_suas.views.auvsi_admin.evaluate_teams import EvaluateTeams
 from auvsi_suas.views.auvsi_admin.export_kml import ExportKml
 from auvsi_suas.views.auvsi_admin.index import Index
 from auvsi_suas.views.auvsi_admin.live_kml import LiveKml, LiveKmlUpdate
@@ -38,10 +37,8 @@ urlpatterns = patterns(
     url(r'^api/clear_cache$', ClearCache.as_view(), name='clear_cache'),
     # Admin access views
     url(r'^$', Index.as_view(), name='index'),
-    url(r'^auvsi_admin/evaluate_teams$', EvaluateTeamsJson.as_view(),
-        name='evaluate_teams'),
-    url(r'^auvsi_admin/evaluate_teams\.csv$',
-        EvaluateTeamsCsv.as_view(), name='evaluate_teams_csv'),
+    url(r'^auvsi_admin/evaluate_teams\.zip$',
+        EvaluateTeams.as_view(), name='evaluate_teams'),
     url(r'^auvsi_admin/export_data\.kml$', ExportKml.as_view(),
         name='export_data'),
     url(r'^auvsi_admin/live\.kml$', LiveKml.as_view(), name='live_kml'),


### PR DESCRIPTION
A single zip file makes it more efficient to get both json and csv back
at the same time (csv for higher-level scoring, json for team feedback).
Per team json makes creating a single PDF for feedback easier as it
doesn't require parsing the json to break out by team.

For #218