### PR TITLE
Add description_approval field. Update scoring.

### DIFF
--- a/server/auvsi_suas/migrations/0027_target_description_approved.py
+++ b/server/auvsi_suas/migrations/0027_target_description_approved.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [('auvsi_suas', '0026_mission_judge_feedback'), ]
+
+    operations = [
+        migrations.AddField(model_name='target',
+                            name='description_approved',
+                            field=models.NullBooleanField(), ),
+    ]

--- a/server/auvsi_suas/proto/target.proto
+++ b/server/auvsi_suas/proto/target.proto
@@ -40,14 +40,16 @@ message TargetEvaluation {
 
     // Whether the image was approved by judge.
     optional bool image_approved = 9;
+    // Whether the emergent description was approved by judge.
+    optional bool description_approved = 10;
     // Ratio of classifications which matched.
-    optional double classifications_ratio = 10;
+    optional double classifications_ratio = 11;
     // Distance of real and submitted target positions (feet).
-    optional double geolocation_accuracy_ft = 11;
+    optional double geolocation_accuracy_ft = 12;
     // Whether the submission is actionable.
-    optional bool actionable_submission = 12;
+    optional bool actionable_submission = 13;
     // Whether the submission was autonomous.
-    optional bool autonomous_submission = 13;
+    optional bool autonomous_submission = 14;
     // Whether the submission was over interop.
-    optional bool interop_submission = 14;
+    optional bool interop_submission = 15;
 }

--- a/server/auvsi_suas/static/auvsi_suas/pages/target-review/target-review-controller.js
+++ b/server/auvsi_suas/static/auvsi_suas/pages/target-review/target-review-controller.js
@@ -97,44 +97,41 @@ TargetReviewCtrl.prototype.getTargetButtonClass = function(target) {
 TargetReviewCtrl.prototype.setReviewTarget = function(target) {
     this.target_ = target;
 
-    if (target == null) {
-        this.targetDetails_ = null;
+    if (this.target_ == null) {
         return;
     }
 
     this.targetDetails_ = [
         {'key': 'ID',
-         'value': target.id},
+         'value': this.target_.id},
         {'key': 'Type',
-         'value': target.type},
+         'value': this.target_.type},
     ];
-    if (target.type == 'standard' || target.type == 'off_axis') {
+    if (this.target_.type == 'standard' || this.target_.type == 'off_axis') {
         this.targetDetails_ = this.targetDetails_.concat([
             {'key': 'Alpha Color',
-             'value': target.alphanumeric_color},
+             'value': this.target_.alphanumeric_color},
             {'key': 'Alpha',
-             'value': target.alphanumeric},
+             'value': this.target_.alphanumeric},
             {'key': 'Shape Color',
-             'value': target.background_color},
+             'value': this.target_.background_color},
             {'key': 'Shape',
-             'value': target.shape}
+             'value': this.target_.shape}
         ]);
     } else {
         this.targetDetails_ = this.targetDetails_.concat([
             {'key': 'Desc',
-             'value': target.description}
+             'value': this.target_.description}
         ]);
     }
 };
 
 
 /**
- * Sets the review status for the target under review. Advances to
+ * Saves the review status for the target under review. Advances to
  * the next target for review.
- * @param {bool} approved The review status to set.
  */
-TargetReviewCtrl.prototype.setReview = function(approved) {
-    this.target_.thumbnail_approved = approved;
+TargetReviewCtrl.prototype.saveReview = function() {
     this.target_.$put().then(
             angular.bind(this, this.nextTarget_));
 };
@@ -167,9 +164,9 @@ TargetReviewCtrl.prototype.getTargetImgHeight = function() {
 TargetReviewCtrl.prototype.setTargets_ = function(targets) {
     this.targets_ = targets;
     if (this.targets_.length > 0) {
-        this.target_ = this.targets_[0];
+        this.setReviewTarget(this.targets_[0]);
     } else {
-        this.target_ = null;
+        this.setReviewTarget(null);
     }
 };
 

--- a/server/auvsi_suas/static/auvsi_suas/pages/target-review/target-review-controller_test.js
+++ b/server/auvsi_suas/static/auvsi_suas/pages/target-review/target-review-controller_test.js
@@ -57,7 +57,8 @@ describe("TargetReviewCtrl controller", function() {
 
         var target = targetReviewCtrl.getReviewTargets()[0];
         targetReviewCtrl.setReviewTarget(target);
-        targetReviewCtrl.setReview(true);
+        target.thumbnail_approved = true;
+        targetReviewCtrl.saveReview();
         httpBackend.flush();
         expect(target.thumbnail_approved).toBe(true);
     });

--- a/server/auvsi_suas/static/auvsi_suas/pages/target-review/target-review.css
+++ b/server/auvsi_suas/static/auvsi_suas/pages/target-review/target-review.css
@@ -34,10 +34,6 @@
     text-decoration: underline;
 }
 
-#target-approve-deny {
-    text-align: center;
-}
-
-#target-approve-deny button {
+#target-review button {
     display: inline-block;
 }

--- a/server/auvsi_suas/static/auvsi_suas/pages/target-review/target-review.html
+++ b/server/auvsi_suas/static/auvsi_suas/pages/target-review/target-review.html
@@ -18,15 +18,24 @@
     </div>
   </div>
 
-  <div id="target-detail" class="small-3 columns panel"
+  <div id="target-detail" class="small-3 columns"
        ng-show="targetReviewCtrl.getReviewTarget()">
-    <div id="target-approve-deny">
-        <button type="button" class="success button" ng-click="targetReviewCtrl.setReview(true)">Approve</button>
-        <button type="button" class="alert button" ng-click="targetReviewCtrl.setReview(false)">Deny</button>
+    <div id="target-review" class="panel">
+        <button type="button" class="success button" ng-click="targetReviewCtrl.saveReview()">Save and Advance</button>
+        <h5>
+            <input type="checkbox" ng-model="targetReviewCtrl.getReviewTarget().thumbnail_approved">
+            Thumbnail Approved
+        </h5>
+        <h5 ng-show="targetReviewCtrl.getReviewTarget().type == 'emergent'">
+            <input type="checkbox" ng-model="targetReviewCtrl.getReviewTarget().description_approved">
+            Emergent Description Approved
+        </h5>
     </div>
-    <div ng-repeat="detail in targetReviewCtrl.getReviewTargetDetails()" >
-        <h4>{{detail.key}}</h4>
-        <h5>{{detail.value}}</h5>
+    <div class="panel">
+        <div ng-repeat="detail in targetReviewCtrl.getReviewTargetDetails()">
+            <h4>{{detail.key}}</h4>
+            <h5>{{detail.value}}</h5>
+        </div>
     </div>
   </div>
 

--- a/server/auvsi_suas/views/targets.py
+++ b/server/auvsi_suas/views/targets.py
@@ -477,7 +477,8 @@ class TargetsAdminReview(View):
         """Updates the review status of a target."""
         try:
             data = json.loads(request.body)
-            approved = bool(data['thumbnail_approved'])
+            thumbnail_approved = bool(data['thumbnail_approved'])
+            description_approved = bool(data['description_approved'])
         except KeyError:
             return HttpResponseBadRequest('Failed to get required field.')
         except ValueError:
@@ -489,7 +490,8 @@ class TargetsAdminReview(View):
             return HttpResponseNotFound('Target %s not found' % pk)
         except ValueError as e:
             return HttpResponseForbidden(str(e))
-        target.thumbnail_approved = approved
+        target.thumbnail_approved = thumbnail_approved
+        target.description_approved = description_approved
         target.save()
         return JsonResponse(target.json(is_superuser=
                                         request.user.is_superuser))

--- a/server/auvsi_suas/views/targets_test.py
+++ b/server/auvsi_suas/views/targets_test.py
@@ -1035,7 +1035,10 @@ class TestTargetsAdminReview(TestCase):
         """Test PUT reivew with invalid pk."""
         response = self.client.put(
             targets_review_id_url(args=[1]),
-            data=json.dumps({'thumbnail_approved': False}))
+            data=json.dumps({
+                'thumbnail_approved': True,
+                'description_approved': True,
+            }))
         self.assertEqual(404, response.status_code)
 
     def test_put_review(self):
@@ -1045,13 +1048,18 @@ class TestTargetsAdminReview(TestCase):
 
         response = self.client.put(
             targets_review_id_url(args=[target.pk]),
-            data=json.dumps({'thumbnail_approved': False}))
+            data=json.dumps({
+                'thumbnail_approved': True,
+                'description_approved': True,
+            }))
         self.assertEqual(200, response.status_code)
         data = json.loads(response.content)
         self.assertIn('id', data)
         self.assertEqual(target.pk, data['id'])
         self.assertIn('thumbnail_approved', data)
-        self.assertFalse(data['thumbnail_approved'])
+        self.assertTrue(data['thumbnail_approved'])
+        self.assertTrue(data['description_approved'])
 
         target.refresh_from_db()
-        self.assertFalse(target.thumbnail_approved)
+        self.assertTrue(target.thumbnail_approved)
+        self.assertTrue(target.description_approved)


### PR DESCRIPTION
This adds a field as to whether the emergent description is approved by
the judge. It updates scoring of the emergent target to use this field
when calculating the classification score. It also updates scoring to
give zero value to an image without an approved thumbnail.

Fixes #228