### PR TITLE
Respect telem prereq. Score obstacle avoidance.

### DIFF
--- a/server/auvsi_suas/models/access_log.py
+++ b/server/auvsi_suas/models/access_log.py
@@ -135,6 +135,6 @@ class AccessLog(models.Model):
 
         # Compute rates using the time between log files.
         times_between_logs = np.array(times_between_logs)
-        times_between_max = np.max(times_between_logs)
-        times_between_avg = np.mean(times_between_logs)
+        times_between_max = float(np.max(times_between_logs))
+        times_between_avg = float(np.mean(times_between_logs))
         return (times_between_max, times_between_avg)

--- a/server/auvsi_suas/proto/mission.proto
+++ b/server/auvsi_suas/proto/mission.proto
@@ -127,16 +127,17 @@ message TimelineScore {
 // Scoring data for autonomous flight.
 message AutonomousFlightScore {
     optional double score_ratio = 1;
-    optional double flight = 2;
-    optional double waypoint_capture = 3;
-    optional double waypoint_accuracy = 4;
-    optional double out_of_bounds_penalty = 5;
+    optional bool telemetry_prerequisite = 2;
+    optional double flight = 3;
+    optional double waypoint_capture = 4;
+    optional double waypoint_accuracy = 5;
+    optional double out_of_bounds_penalty = 6;
 }
 
 // Scoring data for obstacle avoidance.
 message ObstacleAvoidanceScore {
-    optional bool telemetry_prerequisite = 1;
-    optional double score_ratio = 2;
+    optional double score_ratio = 1;
+    optional bool telemetry_prerequisite = 2;
     optional double stationary_obstacle = 3;
     optional double moving_obstacle = 4;
 }

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -204,6 +204,9 @@ OUT_OF_BOUNDS_DEBOUNCE_SEC = 10.0
 # The max distance for a waypoint to be considered satisfied.
 SATISFIED_WAYPOINT_DIST_MAX_FT = 100
 
+# The time between interop telemetry posts that's a prereq for other tasks.
+INTEROP_TELEM_THRESHOLD_TIME_SEC = 1.0
+
 # Ratio of object points to lose for every extra unmatched object submitted.
 EXTRA_OBJECT_PENALTY_RATIO = 0.05
 # The weight of classification accuracy when calculating a target match score.
@@ -249,3 +252,8 @@ AUTONOMOUS_FLIGHT_FLIGHT_WEIGHT = 0.4
 WAYPOINT_CAPTURE_WEIGHT = 0.1
 # Weight of accuracy points to all autonomous flight.
 WAYPOINT_ACCURACY_WEIGHT = 0.5
+
+# Weight of stationary obstacle avoidance.
+STATIONARY_OBST_WEIGHT = 0.5
+# Weight of moving obstacle avoidance.
+MOVING_OBST_WEIGHT = 0.5


### PR DESCRIPTION
Respect the telemetry prerequisite requiring teams to have at least a
1Hz rate of telemetry to get points for waypoint accuracy or for
obstacle avoidance.

Adds scoring of obstacle avoidance.

For #218

As the milestone deadline is approaching, I'm going to submit tomorrow morning sans comments.