### PR TITLE
Require lat/lon for off axis.

### DIFF
--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -1210,11 +1210,14 @@ Targets
    Describe the target characteristics with these fields (see
    :http:post:`/api/targets`):
 
+      * ``latitude``
+      * ``longitude``
       * ``orientation``
       * ``shape``
       * ``background_color``
       * ``alphanumeric``
       * ``alphanumeric_color``
+      * ``autonomous``
 
    * ``emergent`` - Emergent targets are described in section 7.6 of the rules.
 
@@ -1224,6 +1227,7 @@ Targets
       * ``latitude``
       * ``longitude``
       * ``description``
+      * ``autonomous``
 
          * This field should contain a general description of the emergent
            target.


### PR DESCRIPTION
Simplifies interface and implementation compared to special-casing off
axis having a known position. This is what the server has been doing so
far.

Fixes #257 