### PR TITLE
Update penalty weights for takeover and bounds.

### DIFF
--- a/server/auvsi_suas/models/mission_evaluation_test.py
+++ b/server/auvsi_suas/models/mission_evaluation_test.py
@@ -90,11 +90,11 @@ class TestMissionScoring(TestCase):
 
         mission_evaluation.score_team(self.eval)
         self.assertTrue(flight.telemetry_prerequisite)
-        self.assertAlmostEqual(0.5, flight.flight)
+        self.assertAlmostEqual(0.8, flight.flight)
         self.assertAlmostEqual(1, flight.waypoint_capture)
         self.assertAlmostEqual(0.35, flight.waypoint_accuracy)
-        self.assertAlmostEqual(1.4, flight.out_of_bounds_penalty)
-        self.assertAlmostEqual(-0.925, flight.score_ratio)
+        self.assertAlmostEqual(0.3, flight.out_of_bounds_penalty)
+        self.assertAlmostEqual(0.295, flight.score_ratio)
 
         feedback.waypoints[1].score_ratio = 1
         judge.waypoints_captured = 1
@@ -189,7 +189,7 @@ class TestMissionScoring(TestCase):
     def test_total(self):
         """Test the total scoring."""
         mission_evaluation.score_team(self.eval)
-        self.assertAlmostEqual(0.089077781, self.eval.score.score_ratio)
+        self.assertAlmostEqual(0.455077778, self.eval.score.score_ratio)
 
 
 class TestMissionEvaluation(TestCase):
@@ -245,9 +245,9 @@ class TestMissionEvaluation(TestCase):
         self.assertAlmostEqual(0, score.autonomous_flight.flight)
         self.assertAlmostEqual(1, score.autonomous_flight.waypoint_capture)
         self.assertAlmostEqual(0.5, score.autonomous_flight.waypoint_accuracy)
-        self.assertAlmostEqual(1.4,
+        self.assertAlmostEqual(0.3,
                                score.autonomous_flight.out_of_bounds_penalty)
-        self.assertAlmostEqual(-1.05, score.autonomous_flight.score_ratio)
+        self.assertAlmostEqual(0.05, score.autonomous_flight.score_ratio)
 
         self.assertAlmostEqual(0.8, score.object.characteristics)
         self.assertAlmostEqual(0.423458165692, score.object.geolocation)
@@ -262,7 +262,7 @@ class TestMissionEvaluation(TestCase):
 
         self.assertAlmostEqual(0.8, score.operational_excellence.score_ratio)
 
-        self.assertAlmostEqual(0.153896845146, score.score_ratio)
+        self.assertAlmostEqual(0.48389684514619274, score.score_ratio)
 
         # user1 data
         user_eval = mission_eval.teams[1]

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -242,10 +242,10 @@ MISSION_TIME_PENALTY_FROM_SEC = MISSION_TIME_WEIGHT * 0.01
 AUTONOMOUS_FLIGHT_TIME_SEC = 60.0 * 3.0
 MANUAL_FLIGHT_TIME_SEC = 60.0 * 3.0
 # Ratio of points lost per takeover.
-AUTONOMOUS_FLIGHT_TAKEOVER = 0.25
+AUTONOMOUS_FLIGHT_TAKEOVER = 0.10
 # Ratio of points lost per out of bounds.
-BOUND_PENALTY = 0.2
-SAFETY_BOUND_PENALTY = 1.0
+BOUND_PENALTY = 0.1
+SAFETY_BOUND_PENALTY = 0.1
 # Weight of flight points to all autonomous flight.
 AUTONOMOUS_FLIGHT_FLIGHT_WEIGHT = 0.4
 # Weight of capture points to all autonomous flight.


### PR DESCRIPTION
Reduce manual takeover penalty from 25% to 10%.
Reduce out of bounds penalty from 20% to 10%.
Reduce safety bounds penalty from 100% total to 10% additional

For #264