### PR TITLE
Create more granular health check.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
   # Test server.
   - ./server/test.sh
   - ./server/run.sh
-  - sleep 60
   # Test client.
   - ./client/test.sh
   # Verify that docs build.

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -62,6 +62,7 @@ COPY . .
 
 # Load initial data.
 RUN sudo service postgresql start && \
+    ./healthcheck.py --check_postgres && \
     python manage.py loaddata fixtures/test_fixture.yaml
 
 # Host-mountable sections.
@@ -73,5 +74,5 @@ CMD sudo service postgresql start && \
   sudo service apache2 start && \
   tail -f /dev/null
 
-HEALTHCHECK --interval=10s --timeout=3s \
-    CMD curl -f http://localhost/ || exit 1
+HEALTHCHECK \
+  CMD ./healthcheck.py --check_postgres --check_apache --check_homepage

--- a/server/healthcheck.py
+++ b/server/healthcheck.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""Checks health of server container.
+
+Checks the following:
+    1) Postgres is listening for connections.
+    2) Apache is listening for connections.
+    3) Homepage can be retrieved.
+"""
+
+import argparse
+import requests
+import retrying
+import socket
+
+MAX_DELAY = 5 * 60 * 1000  # 5 minutes.
+WAIT = 1 * 1000  # 1 sec.
+
+
+@retrying.retry(wait_fixed=WAIT, stop_max_delay=MAX_DELAY)
+def check_postgres(host, port):
+    """Check postgres health by attempting to create a TCP connection."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect((host, port))
+    s.close()
+
+
+@retrying.retry(wait_fixed=WAIT, stop_max_delay=MAX_DELAY)
+def check_apache(host, port):
+    """Check apache health by attempting to create a TCP connection."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect((host, port))
+    s.close()
+
+
+@retrying.retry(wait_fixed=WAIT, stop_max_delay=MAX_DELAY)
+def check_homepage(host, port):
+    """Check homepage health by requesting via HTTP."""
+    r = requests.get('http://%s:%d' % (host, port))
+    assert r.status_code == 200
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Checks health of server container.')
+
+    parser.add_argument('--check_postgres', default=False, action='store_true')
+    parser.add_argument('--postgres_host', type=str, default='localhost')
+    parser.add_argument('--postgres_port', type=int, default=5432)
+
+    parser.add_argument('--check_apache', default=False, action='store_true')
+    parser.add_argument('--apache_host', type=str, default='localhost')
+    parser.add_argument('--apache_port', type=int, default=80)
+
+    parser.add_argument('--check_homepage', default=False, action='store_true')
+    parser.add_argument('--homepage_host', type=str, default='localhost')
+    parser.add_argument('--homepage_port', type=int, default=80)
+
+    args = parser.parse_args()
+
+    if args.check_postgres:
+        check_postgres(args.postgres_host, args.postgres_port)
+    if args.check_apache:
+        check_apache(args.apache_host, args.apache_port)
+    if args.check_homepage:
+        check_homepage(args.homepage_host, args.homepage_port)
+
+
+if __name__ == '__main__':
+    main()

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,20 +1,22 @@
-enum34
 Django>=1.8,<1.9
+PyYAML # for loaddata
 django-debug-toolbar>=1.3
 django-sendfile
+enum34
+ipaddress
 iso8601
 matplotlib
-python-memcached
 networkx
 numpy
 pillow
 protobuf>=3.2
 psycopg2
 pyproj
-PyYAML # for loaddata
+python-memcached
+requests
+retrying
 scipy
 simplekml==1.2.7
-ipaddress
 
 # yapf is used for automated formatting of Python files.
 # Since it can be finicky from version to version, we fix

--- a/server/run.sh
+++ b/server/run.sh
@@ -3,8 +3,8 @@
 
 docker run -d --restart=unless-stopped --interactive --tty --publish 8000:80 --name interop-server auvsisuas/interop-server
 
-# Poll server up to 2 min for healthiness before proceeding.
-for i in {1..120};
+# Poll server up to 5 min for healthiness before proceeding.
+for i in {1..300};
 do
     docker inspect -f "{{.State.Health.Status}}" interop-server | grep "^healthy$" && exit 0 || sleep 1;
 done


### PR DESCRIPTION
Use it to check for postgres health prior to trying to insert data into
the postgres database. Use it instead of flaky and slower-than-needed
sleep calls.

Fixes #273