### PR TITLE
Use filter_vertical for ManyToManyFields in admin

### DIFF
--- a/server/auvsi_suas/admin.py
+++ b/server/auvsi_suas/admin.py
@@ -17,10 +17,19 @@ from auvsi_suas.models.waypoint import Waypoint
 class LargeDataModelAdmin(admin.ModelAdmin):
     show_full_result_count = False
 
+
+# Define model admin which has scrollable select boxes
+# By default on chrome select has overflow-x: hidden
+class ScollableFilterModelAdmin(admin.ModelAdmin):
+    class Media:
+        css = {"all": ("auvsi_suas/admin/scroll_filter.css", )}
+
 # Register models for admin page
 
 # Only display raw ID fields for ForeignKeys which may contain large amounts
 # of data.
+
+# Use filter_horizontal for ManyToMany fields to easier choose items
 
 
 @admin.register(AerialPosition)
@@ -30,9 +39,11 @@ class AerialPositionModelAdmin(LargeDataModelAdmin):
 
 
 @admin.register(MissionConfig)
-class MissionConfigModelAdmin(admin.ModelAdmin):
+class MissionConfigModelAdmin(ScollableFilterModelAdmin):
     raw_id_fields = ("home_pos", "emergent_last_known_pos",
                      "off_axis_target_pos", "air_drop_pos")
+    filter_vertical = ("fly_zones", "mission_waypoints", "search_grid_points",
+                       "targets", "stationary_obstacles", "moving_obstacles")
 
 
 @admin.register(StationaryObstacle)
@@ -55,10 +66,18 @@ class UasTelemetryModelAdmin(LargeDataModelAdmin):
 class WaypointModelAdmin(LargeDataModelAdmin):
     raw_id_fields = ("position", )
 
+
+@admin.register(FlyZone)
+class FlyZoneModelAdmin(ScollableFilterModelAdmin):
+    filter_vertical = ("boundary_pts", )
+
+
+@admin.register(MovingObstacle)
+class MovingObstacleModelAdmin(ScollableFilterModelAdmin):
+    filter_vertical = ("waypoints", )
+
 # These don't require any raw fields.
-admin.site.register(FlyZone)
 admin.site.register(GpsPosition, LargeDataModelAdmin)
 admin.site.register(MissionClockEvent)
 admin.site.register(MissionJudgeFeedback)
-admin.site.register(MovingObstacle)
 admin.site.register(TakeoffOrLandingEvent)

--- a/server/auvsi_suas/static/auvsi_suas/admin/scroll_filter.css
+++ b/server/auvsi_suas/static/auvsi_suas/admin/scroll_filter.css
@@ -1,0 +1,3 @@
+select[multiple="multiple"] {
+  overflow-x: auto;
+}


### PR DESCRIPTION
Also add some custom CSS to the admin page to allow the filter
vertical to scroll, becasue by default on chrome they do not scroll horizontally and
many of the models have very long string representations.

Closes #272