### PR TITLE
Remove interop submit points. Update odlc weights.

### DIFF
--- a/server/auvsi_suas/models/mission_evaluation.py
+++ b/server/auvsi_suas/models/mission_evaluation.py
@@ -214,7 +214,6 @@ def score_team(team_eval):
         ('geolocation_score_ratio', 'geolocation'),
         ('actionable_score_ratio', 'actionable'),
         ('autonomous_score_ratio', 'autonomy'),
-        ('interop_score_ratio', 'interoperability'),
     ]
     for eval_field, score_field in object_field_mapping:
         total = reduce(lambda x, y: x + y,

--- a/server/auvsi_suas/models/mission_evaluation_test.py
+++ b/server/auvsi_suas/models/mission_evaluation_test.py
@@ -43,14 +43,12 @@ class TestMissionScoring(TestCase):
         t.geolocation_score_ratio = 0.2
         t.actionable_score_ratio = 1.0
         t.autonomous_score_ratio = 1.0
-        t.interop_score_ratio = 1.0
         t = odlcs.odlcs.add()
         t.score_ratio = 0.16
         t.classifications_score_ratio = 0.2
         t.geolocation_score_ratio = 0.6
         t.actionable_score_ratio = 0.0
         t.autonomous_score_ratio = 0.0
-        t.interop_score_ratio = 0.0
         judge = feedback.judge
         judge.flight_time_sec = 60 * 6
         judge.post_process_time_sec = 60 * 4
@@ -167,7 +165,6 @@ class TestMissionScoring(TestCase):
         self.assertAlmostEqual(0.4, objects.geolocation)
         self.assertAlmostEqual(0.5, objects.actionable)
         self.assertAlmostEqual(0.5, objects.autonomy)
-        self.assertAlmostEqual(0.5, objects.interoperability)
         self.assertAlmostEqual(0.1, objects.extra_object_penalty)
         self.assertAlmostEqual(0.46, objects.score_ratio)
 
@@ -234,7 +231,7 @@ class TestMissionEvaluation(TestCase):
         self.assertAlmostEqual(0.5, feedback.uas_telemetry_time_max_sec)
         self.assertAlmostEqual(1. / 6, feedback.uas_telemetry_time_avg_sec)
 
-        self.assertAlmostEqual(0.445, feedback.odlc.score_ratio, places=3)
+        self.assertAlmostEqual(0.454, feedback.odlc.score_ratio, places=3)
 
         self.assertEqual(25, feedback.stationary_obstacles[0].id)
         self.assertEqual(True, feedback.stationary_obstacles[0].hit)
@@ -266,16 +263,15 @@ class TestMissionEvaluation(TestCase):
         self.assertAlmostEqual(0.423458165692, score.object.geolocation)
         self.assertAlmostEqual(0.333333333333, score.object.actionable)
         self.assertAlmostEqual(0.333333333333, score.object.autonomy)
-        self.assertAlmostEqual(0.333333333333, score.object.interoperability)
         self.assertAlmostEqual(0, score.object.extra_object_penalty)
-        self.assertAlmostEqual(0.444691633138, score.object.score_ratio)
+        self.assertAlmostEqual(0.4537041163742234, score.object.score_ratio)
 
         self.assertAlmostEqual(0, score.air_delivery.delivery_accuracy)
         self.assertAlmostEqual(1, score.air_delivery.score_ratio)
 
         self.assertAlmostEqual(0.8, score.operational_excellence.score_ratio)
 
-        self.assertAlmostEqual(0.6038968451461928, score.score_ratio)
+        self.assertAlmostEqual(0.6056993417933632, score.score_ratio)
 
         # user1 data
         user_eval = mission_eval.teams[1]
@@ -326,7 +322,6 @@ class TestMissionEvaluation(TestCase):
         self.assertAlmostEqual(0, score.object.geolocation)
         self.assertAlmostEqual(0, score.object.actionable)
         self.assertAlmostEqual(0, score.object.autonomy)
-        self.assertAlmostEqual(0, score.object.interoperability)
         self.assertAlmostEqual(0, score.object.extra_object_penalty)
         self.assertAlmostEqual(0, score.object.score_ratio)
 

--- a/server/auvsi_suas/proto/mission.proto
+++ b/server/auvsi_suas/proto/mission.proto
@@ -150,12 +150,12 @@ message ObstacleAvoidanceScore {
 
 // Scoring data for objects.
 message ObjectScore {
+    // reserved 6;
     optional double score_ratio = 1;
     optional double characteristics = 2;
     optional double geolocation = 3;
     optional double actionable = 4;
     optional double autonomy = 5;
-    optional double interoperability = 6;
     optional double extra_object_penalty = 7;
 }
 

--- a/server/auvsi_suas/proto/odlc.proto
+++ b/server/auvsi_suas/proto/odlc.proto
@@ -20,6 +20,8 @@ message MultiOdlcEvaluation {
 
 // Evaluation data for a single odlc.
 message OdlcEvaluation {
+    // reserved 8, 15;
+
     // Identifier for the real odlc.
     optional int64 real_odlc = 1;
     // Identifier for the submitted odlc.
@@ -35,8 +37,6 @@ message OdlcEvaluation {
     optional double actionable_score_ratio = 6;
     // Ratio of points for autonomy.
     optional double autonomous_score_ratio = 7;
-    // Ratio of points for interop submission.
-    optional double interop_score_ratio = 8;
 
     // Whether the image was approved by judge.
     optional bool image_approved = 9;
@@ -50,6 +50,4 @@ message OdlcEvaluation {
     optional bool actionable_submission = 13;
     // Whether the submission was autonomous.
     optional bool autonomous_submission = 14;
-    // Whether the submission was over interop.
-    optional bool interop_submission = 15;
 }

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -214,13 +214,11 @@ CHARACTERISTICS_WEIGHT = 0.2
 # The lowest allowed location accuracy (in feet)
 TARGET_LOCATION_THRESHOLD = 150
 # The weight of geolocation accuracy when calculating a odlc match score.
-GEOLOCATION_WEIGHT = 0.2
+GEOLOCATION_WEIGHT = 0.3
 # The weight of actionable intelligence when calculating a odlc match score.
-ACTIONABLE_WEIGHT = 0.1
+ACTIONABLE_WEIGHT = 0.3
 # The weight of autonomy when calculating a odlc match score.
 AUTONOMY_WEIGHT = 0.2
-# The weight of submission over interop when calculating a odlc match score.
-INTEROPERABILITY_WEIGHT = 0.3
 
 # Weight of timeline points for mission time.
 MISSION_TIME_WEIGHT = 0.8


### PR DESCRIPTION
SUAS 2018 rules changed to require interop submission instead of giving
points for it. Geolocation and actionable absorbed those points.

For #286