### PR TITLE
Unify interpolation on discrete telemetry interp.

### DIFF
--- a/server/auvsi_suas/models/mission_config.py
+++ b/server/auvsi_suas/models/mission_config.py
@@ -152,12 +152,13 @@ class MissionConfig(models.Model):
         return ret
 
     @classmethod
-    def kml_all(cls, kml, missions=None):
+    def kml_all(cls, kml, kml_doc, missions=None):
         """
         Appends kml nodes describing all mission configurations.
 
         Args:
             kml: A simpleKML Container to which the mission data will be added
+            kml_doc: The simpleKML Document to which schemas will be added
             missions: Optional list of mission for which to generate KML. If
                 None, it will use all missions.
         """
@@ -165,14 +166,15 @@ class MissionConfig(models.Model):
             missions = MissionConfig.objects.all()
 
         for mission in missions:
-            mission.kml(kml)
+            mission.kml(kml, kml_doc)
 
-    def kml(self, kml):
+    def kml(self, kml, kml_doc):
         """
         Appends kml nodes describing this mission configurations.
 
         Args:
             kml: A simpleKML Container to which the mission data will be added
+            kml_doc: The simpleKML Document to which schemas will be added
         """
         mission_name = 'Mission {}'.format(self.pk)
         kml_folder = kml.newfolder(name=mission_name)
@@ -243,6 +245,17 @@ class MissionConfig(models.Model):
             pol.style.linestyle.width = 2
             pol.style.polystyle.color = Color.changealphaint(50, Color.blue)
 
-        # Stationary Obstacles
+        # Stationary Obstacles.
         stationary_obstacles_folder = kml_folder.newfolder(
             name='Stationary Obstacles')
+        # TODO: Implement
+
+        # Moving Obstacles.
+        users = User.objects.all()
+        moving_obstacle_periods = []
+        for user in users:
+            moving_obstacle_periods.extend(TakeoffOrLandingEvent.flights(user))
+        moving_obstacles_folder = kml_folder.newfolder(name='Moving Obstacles')
+        for obstacle in self.moving_obstacles.all():
+            obstacle.kml(moving_obstacle_periods, moving_obstacles_folder,
+                         kml_doc)

--- a/server/auvsi_suas/models/mission_config_test.py
+++ b/server/auvsi_suas/models/mission_config_test.py
@@ -165,7 +165,7 @@ class TestMissionConfigModelSampleMission(TestCase):
     def test_toKML(self):
         """Test Generation of kml for all mission data"""
         kml = Kml()
-        MissionConfig.kml_all(kml=kml)
+        MissionConfig.kml_all(kml, kml.document)
         data = kml.kml()
         names = [
             'Off Axis',

--- a/server/auvsi_suas/models/stationary_obstacle.py
+++ b/server/auvsi_suas/models/stationary_obstacle.py
@@ -4,6 +4,7 @@ import numpy as np
 import pyproj
 from auvsi_suas.models import distance
 from auvsi_suas.models import units
+from auvsi_suas.models.uas_telemetry import UasTelemetry
 from gps_position import GpsPosition
 from django.conf import settings
 from django.db import models
@@ -28,93 +29,6 @@ class StationaryObstacle(models.Model):
                                     str(self.cylinder_height),
                                     self.gps_position.__unicode__()))
 
-    def determine_interpolated_collision(self, start_log, end_log, utm):
-        """Determines whether the UAS collided with the obstacle by
-        interpolating between start and end telemetry.
-
-        Args:
-            start_log: A UAS telemetry log.
-            end_log: A UAS telemetry log.
-            utm: The UTM Proj projection to project into.
-        Returns:
-            True if the UAS collided with the obstacle, False otherwise.
-        """
-        start_lat = start_log.uas_position.gps_position.latitude
-        start_lon = start_log.uas_position.gps_position.longitude
-        start_alt = start_log.uas_position.altitude_msl
-
-        end_lat = end_log.uas_position.gps_position.latitude
-        end_lon = end_log.uas_position.gps_position.longitude
-        end_alt = end_log.uas_position.altitude_msl
-
-        latc = self.gps_position.latitude
-        lonc = self.gps_position.longitude
-
-        # First, check if altitude for both logs is above cylinder height.
-        if start_alt > self.cylinder_height and end_alt > self.cylinder_height:
-            return False
-
-        # If at same lat/lon, no need to interpolate.
-        if start_lat == end_lat and start_lon == end_lon:
-            return (self.contains_pos(start_log.uas_position) or
-                    self.contains_pos(end_log.uas_position))
-
-        # We want to check if the line drawn between start_log and end_log
-        # ever crosses the obstacle.
-        # We do this by looking at only the x, y dimensions and checking if the
-        # 2d line intersects with the circle (cylindrical obstacle
-        # cross-section). We then use the line equation to determine the
-        # altitude at which the intersection occurs. If the altitude is between
-        # 0 and self.cylinder_height, a collision occured.
-        # Reference: https://math.stackexchange.com/questions/980089/how-to-check-if-a-3d-line-segment-intersects-a-cylinder
-
-        # Convert points to UTM projection.
-        # We need a cartesian coordinate system to perform the calculation.
-        try:
-            x1, y1 = pyproj.transform(distance.wgs84, utm, start_lon,
-                                      start_lat)
-            z1 = units.feet_to_meters(start_alt)
-            x2, y2 = pyproj.transform(distance.wgs84, utm, end_lon, end_lat)
-            z2 = units.feet_to_meters(end_alt)
-            cx, cy = pyproj.transform(distance.wgs84, utm, lonc, latc)
-        except RuntimeError:
-            # pyproj throws RuntimeError if the coordinates are grossly beyond
-            # the bounds of the projection. We do not count this as a collision.
-            return False
-
-        rm = units.feet_to_meters(self.cylinder_radius)
-        hm = units.feet_to_meters(self.cylinder_height)
-
-        # Calculate equation of line and substitute into circle equation.
-        # Equation of obstacle circle:
-        # (x - latc)^2 + (y - laty)^2 = self.cylinder_radius^2
-        if x2 - x1 == 0:
-            # If delta X is 0, substitute X as constant and solve for y.
-            p = [1, -2 * cy, cy**2 + (x1 - cx)**2 - rm**2]
-            roots = np.roots(p)
-            for root in roots:
-                # Solve for altitude and check if within bounds.
-                zcalc = ((root - y1) * (z2 - z1) / (y2 - y1)) + z1
-                if np.isreal(root) and zcalc <= hm:
-                    return True
-        else:
-            # Calculate slope and intercept of line between start and end log.
-            m = (y2 - y1) / (x2 - x1)
-            b = y1 - m * x1
-            # Substitute in line equation and solve for x.
-            p = [
-                m**2 + 1, (2 * m * (b - cy)) - (2 * cx),
-                cx**2 + (b - cy)**2 - rm**2
-            ]
-            roots = np.roots(p)
-            for root in roots:
-                # Solve for altitude and check if within bounds.
-                zcalc = ((root - x1) * (z2 - z1) / (x2 - x1)) + z1
-                if np.isreal(root) and zcalc <= hm:
-                    return True
-
-        return False
-
     def contains_pos(self, aerial_pos):
         """Whether the pos is contained within the obstacle.
 
@@ -129,10 +43,7 @@ class StationaryObstacle(models.Model):
             return False
         # Check lat/lon of position
         dist_to_center = self.gps_position.distance_to(aerial_pos.gps_position)
-        if dist_to_center > self.cylinder_radius:
-            return False
-        # Both within altitude and radius bounds, inside cylinder
-        return True
+        return dist_to_center <= self.cylinder_radius
 
     def evaluate_collision_with_uas(self, uas_telemetry_logs):
         """Evaluates whether the Uas logs indicate a collision.
@@ -144,18 +55,9 @@ class StationaryObstacle(models.Model):
             Whether a UAS telemetry log reported indicates a collision with the
             obstacle.
         """
-        zone, north = distance.utm_zone(self.gps_position.latitude,
-                                        self.gps_position.longitude)
-        utm = distance.proj_utm(zone, north)
-        for i, cur_log in enumerate(uas_telemetry_logs):
-            cur_log = uas_telemetry_logs[i]
-            if self.contains_pos(cur_log.uas_position):
+        for log in UasTelemetry.interpolate(uas_telemetry_logs):
+            if self.contains_pos(log.uas_position):
                 return True
-            if i > 0:
-                if self.determine_interpolated_collision(
-                        uas_telemetry_logs[i - 1], cur_log, utm):
-                    return True
-
         return False
 
     def json(self):

--- a/server/auvsi_suas/models/uas_telemetry_test.py
+++ b/server/auvsi_suas/models/uas_telemetry_test.py
@@ -24,19 +24,109 @@ class TestUasTelemetryBase(TestCase):
         self.user = User.objects.create_user('testuser', 'testemail@x.com',
                                              'testpass')
         self.user.save()
+        self.now = timezone.now()
 
-    def create_log_element(self, timestamp, user, lat, lon, alt, heading):
+    def create_log_element(self, timestamp, lat, lon, alt, heading, user=None):
+        if user is None:
+            user = self.user
+
         pos = GpsPosition(latitude=lat, longitude=lon)
         pos.save()
         apos = AerialPosition(gps_position=pos, altitude_msl=alt)
         apos.save()
-        log = UasTelemetry(
-            timestamp=timezone.now(),
-            user=user,
-            uas_position=apos,
-            uas_heading=heading)
+        log = UasTelemetry(user=user, uas_position=apos, uas_heading=heading)
+        log.save()
+        log.timestamp = self.now + datetime.timedelta(seconds=timestamp)
         log.save()
         return log
+
+    def create_uas_logs(self, entries, user=None):
+        """Create a list of uas telemetry logs.
+
+        Args:
+            entries: List of (t, lat, lon, alt, heading) tuples for each entry.
+            user: User to create logs for.
+
+        Returns:
+            List of UasTelemetry objects
+        """
+        if user is None:
+            user = self.user
+
+        ret = []
+        for (t, lat, lon, alt, head) in entries:
+            ret.append(self.create_log_element(t, lat, lon, alt, head, user))
+        return ret
+
+    def waypoints_from_data(self, waypoints_data):
+        """Converts tuples of lat/lon/alt to a waypoint."""
+        waypoints = []
+        for i, waypoint in enumerate(waypoints_data):
+            (lat, lon, alt) = waypoint
+            pos = GpsPosition()
+            pos.latitude = lat
+            pos.longitude = lon
+            pos.save()
+            apos = AerialPosition()
+            apos.altitude_msl = alt
+            apos.gps_position = pos
+            apos.save()
+            wpt = Waypoint()
+            wpt.position = apos
+            wpt.order = i
+            wpt.save()
+            waypoints.append(wpt)
+        return waypoints
+
+    def assertTelemetryEqual(self, expect, got):
+        """Assert two telemetry are equal."""
+        msg = '%s != %s' % (expect, got)
+        self.assertAlmostEqual(
+            expect.uas_position.gps_position.latitude,
+            got.uas_position.gps_position.latitude,
+            places=6,
+            msg=msg)
+        self.assertAlmostEqual(
+            expect.uas_position.gps_position.longitude,
+            got.uas_position.gps_position.longitude,
+            places=6,
+            msg=msg)
+        self.assertAlmostEqual(
+            expect.uas_position.altitude_msl,
+            got.uas_position.altitude_msl,
+            places=3,
+            msg=msg)
+        self.assertAlmostEqual(
+            expect.uas_heading, got.uas_heading, places=3, msg=msg)
+
+    def assertTelemetriesEqual(self, expect, got):
+        "Assert two lists of telemetry are equal." ""
+        expect = [i for i in expect]
+        got = [i for i in got]
+        self.assertEqual(len(expect), len(got))
+        for ix in xrange(len(expect)):
+            self.assertTelemetryEqual(expect[ix], got[ix])
+
+    def assertSatisfiedWaypoints(self, expect, got):
+        """Assert two satisfied_waypoints return values are equal."""
+        msg = '%s != %s' % (expect, got)
+        self.assertEqual(len(expect), len(got), msg=msg)
+        for i in xrange(len(expect)):
+            e = expect[i]
+            g = got[i]
+            self.assertEqual(e.id, g.id, msg=msg)
+            self.assertAlmostEqual(
+                e.score_ratio, g.score_ratio, places=2, msg=msg)
+            self.assertAlmostEqual(
+                e.closest_for_scored_approach_ft,
+                g.closest_for_scored_approach_ft,
+                delta=5,
+                msg=msg)
+            self.assertAlmostEqual(
+                e.closest_for_mission_ft,
+                g.closest_for_mission_ft,
+                delta=5,
+                msg=msg)
 
 
 class TestUasTelemetry(TestUasTelemetryBase):
@@ -46,12 +136,7 @@ class TestUasTelemetry(TestUasTelemetryBase):
         super(TestUasTelemetry, self).setUp()
 
         self.log = self.create_log_element(
-            timestamp=timezone.now(),
-            user=self.user,
-            lat=10,
-            lon=100,
-            alt=200,
-            heading=90)
+            timestamp=0, lat=10, lon=100, alt=200, heading=90)
 
     def test_unicode(self):
         """Tests the unicode method executes."""
@@ -60,26 +145,11 @@ class TestUasTelemetry(TestUasTelemetryBase):
     def test_duplicate_unequal(self):
         """Tests duplicate function with unequal telemetry."""
         log1 = self.create_log_element(
-            timestamp=timezone.now(),
-            user=self.user,
-            lat=20,
-            lon=200,
-            alt=200,
-            heading=90)
+            timestamp=0, lat=20, lon=200, alt=200, heading=90)
         log2 = self.create_log_element(
-            timestamp=timezone.now(),
-            user=self.user,
-            lat=10,
-            lon=100,
-            alt=300,
-            heading=90)
+            timestamp=0, lat=10, lon=100, alt=300, heading=90)
         log3 = self.create_log_element(
-            timestamp=timezone.now(),
-            user=self.user,
-            lat=10,
-            lon=100,
-            alt=200,
-            heading=10)
+            timestamp=0, lat=10, lon=100, alt=200, heading=10)
 
         self.assertFalse(self.log.duplicate(log1))
         self.assertFalse(self.log.duplicate(log2))
@@ -88,12 +158,7 @@ class TestUasTelemetry(TestUasTelemetryBase):
     def test_duplicate_equal(self):
         """Tests duplicate function with equal telemetry."""
         log1 = self.create_log_element(
-            timestamp=timezone.now(),
-            user=self.user,
-            lat=10,
-            lon=100,
-            alt=200,
-            heading=90)
+            timestamp=0, lat=10, lon=100, alt=200, heading=90)
 
         self.assertTrue(self.log.duplicate(self.log))
         self.assertTrue(self.log.duplicate(log1))
@@ -119,38 +184,20 @@ class TestUasTelemetry(TestUasTelemetryBase):
         self.assertEqual(90, data['heading'])
 
 
-class TestUasTelemetryDedupe(TestUasTelemetryBase):
+class TestUasTelemetryFilter(TestUasTelemetryBase):
     def setUp(self):
-        super(TestUasTelemetryDedupe, self).setUp()
+        super(TestUasTelemetryFilter, self).setUp()
 
         self.log1 = self.create_log_element(
-            timestamp=timezone.now(),
-            user=self.user,
-            lat=10,
-            lon=200,
-            alt=200,
-            heading=90)
+            timestamp=0, lat=10, lon=200, alt=200, heading=90)
         self.log2 = self.create_log_element(
-            timestamp=timezone.now(),
-            user=self.user,
-            lat=20,
-            lon=200,
-            alt=200,
-            heading=90)
+            timestamp=0, lat=20, lon=200, alt=200, heading=90)
         self.log3 = self.create_log_element(
-            timestamp=timezone.now(),
-            user=self.user,
-            lat=30,
-            lon=200,
-            alt=200,
-            heading=90)
+            timestamp=0, lat=30, lon=200, alt=200, heading=90)
         self.log4 = self.create_log_element(
-            timestamp=timezone.now(),
-            user=self.user,
-            lat=40,
-            lon=200,
-            alt=200,
-            heading=90)
+            timestamp=0, lat=40, lon=200, alt=200, heading=90)
+        self.log5 = self.create_log_element(
+            timestamp=0, lat=0, lon=0, alt=0, heading=0)
 
     def test_no_logs(self):
         """Tests empty log."""
@@ -175,115 +222,78 @@ class TestUasTelemetryDedupe(TestUasTelemetryBase):
         expect = [self.log1, self.log2, self.log3, self.log4]
         self.assertEqual(UasTelemetry.dedupe(orig), expect)
 
-    def create_uas_logs(self, user, entries):
-        """Create a list of uas telemetry logs.
+    def test_filter_bad(self):
+        """Tests filter_bad()."""
+        orig = [self.log1, self.log5]
+        expect = [self.log1]
+        self.assertEqual(UasTelemetry.filter_bad(orig), expect)
 
-        Args:
-            user: User to create logs for.
-            entries: List of (lat, lon, alt) tuples for each entry.
 
-        Returns:
-            List of UasTelemetry objects
-        """
-        ret = []
+class TestUasTelemetryInterpolate(TestUasTelemetryBase):
+    """Tests the UasTelemetry interpolate()."""
 
-        for (lat, lon, alt) in entries:
-            pos = GpsPosition()
-            pos.latitude = lat
-            pos.longitude = lon
-            pos.save()
-            apos = AerialPosition()
-            apos.altitude_msl = alt
-            apos.gps_position = pos
-            apos.save()
-            log = UasTelemetry()
-            log.user = user
-            log.uas_position = apos
-            log.uas_heading = 0
-            log.save()
-            ret.append(log)
+    def test_single_point(self):
+        """Tests handles ranges of points."""
+        self.assertTelemetriesEqual(
+            self.create_uas_logs([
+                (0, 38, -76, 100, 0),
+            ]),
+            UasTelemetry.interpolate(
+                self.create_uas_logs([
+                    (0, 38, -76, 100, 0),
+                ])))
 
-        return ret
+    def test_position(self):
+        """Tests the returned interpolated position."""
+        self.assertTelemetriesEqual(
+            self.create_uas_logs([
+                (0.0, 38, -76, 100, 0),
+                (0.1, 39, -75, 105, 1),
+                (0.2, 40, -74, 110, 2),
+                (0.3, 41, -73, 115, 3),
+                (0.4, 42, -72, 120, 4),
+                (0.5, 43, -71, 130, 5),
+                (0.6, 44, -70, 140, 6),
+                (0.7, 45, -69, 150, 7),
+            ]),
+            UasTelemetry.interpolate(
+                self.create_uas_logs([
+                    (0.0, 38, -76, 100, 0),
+                    (0.2, 40, -74, 110, 2),
+                    (0.4, 42, -72, 120, 4),
+                    (0.7, 45, -69, 150, 7),
+                ])))
 
-    def assertSatisfiedWaypoints(self, expect, got):
-        """Assert two satisfied_waypoints return values are equal."""
-        msg = '%s != %s' % (expect, got)
-        self.assertEqual(len(expect), len(got), msg=msg)
-        for i in xrange(len(expect)):
-            e = expect[i]
-            g = got[i]
-            self.assertEqual(e.id, g.id, msg=msg)
-            self.assertAlmostEqual(
-                e.score_ratio, g.score_ratio, places=2, msg=msg)
-            self.assertAlmostEqual(
-                e.closest_for_scored_approach_ft,
-                g.closest_for_scored_approach_ft,
-                places=2,
-                msg=msg)
-            self.assertAlmostEqual(
-                e.closest_for_mission_ft,
-                g.closest_for_mission_ft,
-                places=2,
-                msg=msg)
+    def test_over_step(self):
+        """Tests it doesn't interpolate when dt less than step."""
+        self.assertTelemetriesEqual(
+            self.create_uas_logs([
+                (0.0, 38, -76, 100, 0),
+                (0.1, 38, -76, 110, 0),
+                (0.2, 38, -76, 120, 0),
+            ]),
+            UasTelemetry.interpolate(
+                self.create_uas_logs([
+                    (0.0, 38, -76, 100, 0),
+                    (0.1, 38, -76, 110, 0),
+                    (0.2, 38, -76, 120, 0),
+                ])))
 
-    def waypoints_from_data(self, waypoints_data):
-        """Converts tuples of lat/lon/alt to a waypoint."""
-        waypoints = []
-        for i, waypoint in enumerate(waypoints_data):
-            (lat, lon, alt) = waypoint
-            pos = GpsPosition()
-            pos.latitude = lat
-            pos.longitude = lon
-            pos.save()
-            apos = AerialPosition()
-            apos.altitude_msl = alt
-            apos.gps_position = pos
-            apos.save()
-            wpt = Waypoint()
-            wpt.position = apos
-            wpt.order = i
-            wpt.save()
-            waypoints.append(wpt)
-        return waypoints
+    def test_over_max_gap(self):
+        """Tests it doesn't interpolate when over the max gap."""
+        self.assertTelemetriesEqual(
+            self.create_uas_logs([
+                (00, 38, -76, 100, 0),
+                (10, 38, -76, 110, 0),
+            ]),
+            UasTelemetry.interpolate(
+                self.create_uas_logs([
+                    (00, 38, -76, 100, 0),
+                    (10, 38, -76, 110, 0),
+                ])))
 
-    def test_closest_interpolated_distance(self):
-        utm = distance.proj_utm(zone=18, north=True)
 
-        # Test velocity filter.
-        waypoint = self.waypoints_from_data([(38, -76, 100)])[0]
-        entries = [(38, -76, 140), (40, -78, 600)]
-        logs = self.create_uas_logs(self.user, entries)
-        d = UasTelemetry.closest_interpolated_distance(logs[0], logs[1],
-                                                       waypoint.position, utm)
-        self.assertAlmostEqual(40.0, d, delta=3)
-
-        # Test telemetry rate filter.
-        waypoint = self.waypoints_from_data([(38.145147, -76.427583, 100)])[0]
-        entries = [(38.145148, -76.427645, 100), (38.145144, -76.427400, 100)]
-        logs = self.create_uas_logs(self.user, entries)
-        logs[1].timestamp = logs[0].timestamp + datetime.timedelta(seconds=2)
-        d = UasTelemetry.closest_interpolated_distance(logs[0], logs[1],
-                                                       waypoint.position, utm)
-        self.assertAlmostEqual(17.792, d, delta=3)
-
-        # Test interpolation (waypoint is halfway between telemetry logs).
-        waypoint = self.waypoints_from_data([(38.145146, -76.427522, 80)])[0]
-        entries = [(38.145148, -76.427645, 100), (38.145144, -76.427400, 100)]
-        logs = self.create_uas_logs(self.user, entries)
-        logs[1].timestamp = logs[0].timestamp + datetime.timedelta(seconds=1)
-        d = UasTelemetry.closest_interpolated_distance(logs[0], logs[1],
-                                                       waypoint.position, utm)
-        self.assertAlmostEqual(20.0, d, delta=3)
-
-        # Test dt = 0 uses min distance.
-        waypoint = self.waypoints_from_data([(38.145146, -76.427522, 80)])[0]
-        entries = [(38.145146, -76.427522, 100), (38.145146, -76.427522, 120)]
-        logs = self.create_uas_logs(self.user, entries)
-        logs[1].timestamp = logs[0].timestamp
-        d = UasTelemetry.closest_interpolated_distance(logs[0], logs[1],
-                                                       waypoint.position, utm)
-        self.assertAlmostEqual(20.0, d, delta=3)
-
+class TestUasTelemetryWaypoints(TestUasTelemetryBase):
     def test_satisfied_waypoints(self):
         """Tests the evaluation of waypoints method."""
         # Create mission config
@@ -292,15 +302,18 @@ class TestUasTelemetryDedupe(TestUasTelemetryBase):
         gpos.longitude = 10
         gpos.save()
 
-        # Create waypoints for testing.
-        waypoints = self.waypoints_from_data([(38, -76, 100), (39, -77, 200),
-                                              (40, -78, 0)])
-
-        # Create UAS telemetry logs
+        waypoints = self.waypoints_from_data([
+            (38, -76, 100),
+            (39, -77, 200),
+            (40, -78, 0),
+        ])
 
         # Only first is valid.
-        entries = [(38, -76, 140), (40, -78, 600), (37, -75, 40)]
-        logs = self.create_uas_logs(self.user, entries)
+        logs = self.create_uas_logs([
+            (0, 38, -76, 140, 0),
+            (1, 40, -78, 600, 0),
+            (2, 37, -75, 40, 0),
+        ])
         expect = [
             WaypointEvaluation(
                 id=0,
@@ -308,7 +321,7 @@ class TestUasTelemetryDedupe(TestUasTelemetryBase):
                 closest_for_scored_approach_ft=40,
                 closest_for_mission_ft=40),
             WaypointEvaluation(
-                id=1, score_ratio=0, closest_for_mission_ft=460785.17),
+                id=1, score_ratio=0, closest_for_mission_ft=170),
             WaypointEvaluation(
                 id=2, score_ratio=0, closest_for_mission_ft=600)
         ]
@@ -317,8 +330,11 @@ class TestUasTelemetryDedupe(TestUasTelemetryBase):
                                           gpos, waypoints, logs))
 
         # First and last are valid.
-        entries = [(38, -76, 140), (40, -78, 600), (40, -78, 40)]
-        logs = self.create_uas_logs(self.user, entries)
+        logs = self.create_uas_logs([
+            (0, 38, -76, 140, 0),
+            (1, 40, -78, 600, 0),
+            (2, 40, -78, 40, 0),
+        ])
         expect = [
             WaypointEvaluation(
                 id=0,
@@ -326,7 +342,7 @@ class TestUasTelemetryDedupe(TestUasTelemetryBase):
                 closest_for_scored_approach_ft=40,
                 closest_for_mission_ft=40),
             WaypointEvaluation(
-                id=1, score_ratio=0, closest_for_mission_ft=460785.03),
+                id=1, score_ratio=0, closest_for_mission_ft=170),
             WaypointEvaluation(
                 id=2,
                 score_ratio=0.6,
@@ -338,7 +354,11 @@ class TestUasTelemetryDedupe(TestUasTelemetryBase):
                                           gpos, waypoints, logs))
 
         # Hit all.
-        entries = [(38, -76, 140), (39, -77, 180), (40, -78, 40)]
+        logs = self.create_uas_logs([
+            (0, 38, -76, 140, 0),
+            (1, 39, -77, 180, 0),
+            (2, 40, -78, 40, 0),
+        ])
         expect = [
             WaypointEvaluation(
                 id=0,
@@ -356,22 +376,20 @@ class TestUasTelemetryDedupe(TestUasTelemetryBase):
                 closest_for_scored_approach_ft=40,
                 closest_for_mission_ft=40)
         ]
-        logs = self.create_uas_logs(self.user, entries)
         self.assertSatisfiedWaypoints(expect,
                                       UasTelemetry.satisfied_waypoints(
                                           gpos, waypoints, logs))
 
         # Only hit the first waypoint on run one, hit all on run two.
-        entries = [
-            (38, -76, 140),
-            (40, -78, 600),
-            (37, -75, 40),
+        logs = self.create_uas_logs([
+            (0, 38, -76, 140, 0),
+            (1, 40, -78, 600, 0),
+            (2, 37, -75, 40, 0),
             # Run two:
-            (38, -76, 140),
-            (39, -77, 180),
-            (40, -78, 40)
-        ]
-        logs = self.create_uas_logs(self.user, entries)
+            (3, 38, -76, 140, 0),
+            (4, 39, -77, 180, 0),
+            (5, 40, -78, 40, 0),
+        ])
         expect = [
             WaypointEvaluation(
                 id=0,
@@ -394,15 +412,15 @@ class TestUasTelemetryDedupe(TestUasTelemetryBase):
                                           gpos, waypoints, logs))
 
         # Hit all on run one, only hit the first waypoint on run two.
-        entries = [
-            (38, -76, 140),
-            (39, -77, 180),
-            (40, -78, 40),
+        logs = self.create_uas_logs([
+            (0, 38, -76, 140, 0),
+            (1, 39, -77, 180, 0),
+            (2, 40, -78, 40, 0),
             # Run two:
-            (38, -76, 140),
-            (40, -78, 600),
-            (37, -75, 40)
-        ]
+            (3, 38, -76, 140, 0),
+            (4, 40, -78, 600, 0),
+            (5, 37, -75, 40, 0)
+        ])
         expect = [
             WaypointEvaluation(
                 id=0,
@@ -420,15 +438,17 @@ class TestUasTelemetryDedupe(TestUasTelemetryBase):
                 closest_for_scored_approach_ft=40,
                 closest_for_mission_ft=40)
         ]
-        logs = self.create_uas_logs(self.user, entries)
         self.assertSatisfiedWaypoints(expect,
                                       UasTelemetry.satisfied_waypoints(
                                           gpos, waypoints, logs))
 
         # Keep flying after hitting all waypoints.
-        entries = [(38, -76, 140), (39, -77, 180), (40, -78, 40), (30.1, -78.1,
-                                                                   100)]
-        logs = self.create_uas_logs(self.user, entries)
+        logs = self.create_uas_logs([
+            (0, 38, -76, 140, 0),
+            (1, 39, -77, 180, 0),
+            (2, 40, -78, 40, 0),
+            (3, 30.1, -78.1, 100, 0),
+        ])
         expect = [
             WaypointEvaluation(
                 id=0,
@@ -451,16 +471,15 @@ class TestUasTelemetryDedupe(TestUasTelemetryBase):
                                           gpos, waypoints, logs))
 
         # Hit all in first run, but second is higher scoring.
-        entries = [
-            (38, -76, 140),
-            (39, -77, 180),
-            (40, -78, 60),
+        logs = self.create_uas_logs([
+            (0, 38, -76, 140, 0),
+            (1, 39, -77, 180, 0),
+            (2, 40, -78, 60, 0),
             # Run two:
-            (38, -76, 100),
-            (39, -77, 200),
-            (40, -78, 110)
-        ]
-        logs = self.create_uas_logs(self.user, entries)
+            (3, 38, -76, 100, 0),
+            (4, 39, -77, 200, 0),
+            (5, 40, -78, 110, 0)
+        ])
         expect = [
             WaypointEvaluation(
                 id=0,
@@ -479,17 +498,19 @@ class TestUasTelemetryDedupe(TestUasTelemetryBase):
                                           gpos, waypoints, logs))
 
         # Restart waypoint path in the middle, use path in between points.
-        waypoints = self.waypoints_from_data([(38, -76, 100), (39, -77, 200),
-                                              (40, -78, 0)])
-        entries = [
-            (38, -76, 140),  # Use
-            (39, -77, 180),  # Use
+        waypoints = self.waypoints_from_data([
+            (38, -76, 100),
+            (39, -77, 200),
+            (40, -78, 0),
+        ])
+        logs = self.create_uas_logs([
+            (0, 38, -76, 140, 0),  # Use
+            (1, 39, -77, 180, 0),  # Use
             # Restart:
-            (38, -76, 70),
-            (39, -77, 150),
-            (40, -78, 10)
-        ]  # Use
-        logs = self.create_uas_logs(self.user, entries)
+            (2, 38, -76, 70, 0),
+            (3, 39, -77, 150, 0),
+            (4, 40, -78, 10, 0),  # Use
+        ])
         expect = [
             WaypointEvaluation(
                 id=0,
@@ -512,61 +533,55 @@ class TestUasTelemetryDedupe(TestUasTelemetryBase):
                                           gpos, waypoints, logs))
 
         # Sanity check waypoint scoring with interpolation.
-        waypoints = self.waypoints_from_data([(38.145146, -76.427522, 80),
-                                              (38.1447, -76.4272, 100)])
-        entries = [(38.145148, -76.427645, 100), (38.145144, -76.427400, 100),
-                   (38.1447, -76.4275, 100), (38.145145, -76.427461, 80)]
-        logs = self.create_uas_logs(self.user, entries)
-        for i in range(1, len(logs)):
-            logs[i].timestamp = (
-                logs[i - 1].timestamp + datetime.timedelta(seconds=1))
+        waypoints = self.waypoints_from_data([
+            (38, -76, 70),
+            (38, -76, 110),
+        ])
+        logs = self.create_uas_logs([
+            (0, 38, -76, 0, 0),
+            (1, 38, -76, 200, 0),
+        ])
         expect = [
             WaypointEvaluation(
                 id=0,
-                score_ratio=0.8,
-                closest_for_scored_approach_ft=20,
-                closest_for_mission_ft=17.505),
+                score_ratio=0.9,
+                closest_for_scored_approach_ft=10,
+                closest_for_mission_ft=10),
             WaypointEvaluation(
                 id=1,
-                score_ratio=0.14,
-                closest_for_scored_approach_ft=86.072,
-                closest_for_mission_ft=86.072)
+                score_ratio=0.9,
+                closest_for_scored_approach_ft=10,
+                closest_for_mission_ft=10)
         ]
         self.assertSatisfiedWaypoints(expect,
                                       UasTelemetry.satisfied_waypoints(
                                           gpos, waypoints, logs))
 
 
-class TestUasTelemetryKML(TestUasTelemetryBase):
+class TestUasTelemetryKml(TestUasTelemetryBase):
     # String formatter for KML format that expects lon, lat, alt arguments
     coord_format = '<gx:coord>{} {} {}</gx:coord>'
 
-    def create_log_element(self, lat, lon, alt):
-        """Override to define defaults."""
-        super(TestUasTelemetryKML, self).create_log_element(
-            timestamp=timezone.now(),
-            user=self.user,
-            lat=lat,
-            lon=lon,
-            alt=alt,
-            heading=80)
-
     def test_kml_simple(self):
         coordinates = [
-            (-76.0, 38.0, 0.0),
-            (-76.0, 38.0, 10.0),
-            (-76.0, 38.0, 20.0),
-            (-76.0, 38.0, 30.0),
-            (-76.0, 38.0, 100.0),
-            (-76.0, 38.0, 30.0),
-            (-76.0, 38.0, 60.0),
+            (0, -76.0, 38.0, 0.0, 0),
+            (1, -76.0, 38.0, 10.0, 0),
+            (2, -76.0, 38.0, 20.0, 0),
+            (3, -76.0, 38.0, 30.0, 0),
+            (4, -76.0, 38.0, 100.0, 0),
+            (5, -76.0, 38.0, 30.0, 0),
+            (6, -76.0, 38.0, 60.0, 0),
         ]
         # Create Coordinates
         start = TakeoffOrLandingEvent(user=self.user, uas_in_air=True)
         start.save()
+        start.timestamp = self.now
+        start.save()
         for coord in coordinates:
             self.create_log_element(*coord)
         end = TakeoffOrLandingEvent(user=self.user, uas_in_air=False)
+        end.save()
+        end.timestamp = self.now + datetime.timedelta(seconds=7)
         end.save()
 
         kml = Kml()
@@ -574,10 +589,10 @@ class TestUasTelemetryKML(TestUasTelemetryBase):
             user=self.user,
             logs=UasTelemetry.by_user(self.user),
             kml=kml,
-            kml_doc=kml)
+            kml_doc=kml.document)
         for coord in coordinates:
-            tag = self.coord_format.format(coord[1], coord[0],
-                                           units.feet_to_meters(coord[2]))
+            tag = self.coord_format.format(coord[2], coord[1],
+                                           units.feet_to_meters(coord[3]))
             self.assertTrue(tag in kml.kml())
 
     def test_kml_empty(self):
@@ -586,27 +601,34 @@ class TestUasTelemetryKML(TestUasTelemetryBase):
             user=self.user,
             logs=UasTelemetry.by_user(self.user),
             kml=kml,
-            kml_doc=kml)
+            kml_doc=kml.document)
 
     def test_kml_filter(self):
         coordinates = [
-            (-76.0, 38.0, 0.0),
-            (-76.0, 38.0, 10.0),
-            (-76.0, 38.0, 20.0),
-            (-76.0, 38.0, 30.0),
-            (-76.0, 38.0, 100.0),
-            (-76.0, 38.0, 30.0),
-            (-76.0, 38.0, 60.0),
+            (0, -76.0, 38.0, 0.0, 0),
+            (1, -76.0, 38.0, 10.0, 0),
+            (2, -76.0, 38.0, 20.0, 0),
+            (3, -76.0, 38.0, 30.0, 0),
+            (4, -76.0, 38.0, 100.0, 0),
+            (5, -76.0, 38.0, 30.0, 0),
+            (6, -76.0, 38.0, 60.0, 0),
         ]
-        filtered_out = [(0.1, 0.001, 100), (0.0, 0.0, 0)]
+        filtered_out = [
+            (7, 0.1, 0.001, 100, 0),
+            (8, 0.0, 0.0, 0, 0),
+        ]
         # Create Coordinates
         start = TakeoffOrLandingEvent(user=self.user, uas_in_air=True)
+        start.save()
+        start.timestamp = self.now
         start.save()
         for coord in coordinates:
             self.create_log_element(*coord)
         for coord in filtered_out:
             self.create_log_element(*coord)
         end = TakeoffOrLandingEvent(user=self.user, uas_in_air=False)
+        end.save()
+        end.timestamp = self.now + datetime.timedelta(seconds=6.5)
         end.save()
 
         kml = Kml()
@@ -617,11 +639,11 @@ class TestUasTelemetryKML(TestUasTelemetryBase):
             kml_doc=kml)
 
         for filtered in filtered_out:
-            tag = self.coord_format.format(filtered[1], filtered[0],
-                                           units.feet_to_meters(filtered[2]))
+            tag = self.coord_format.format(filtered[2], filtered[1],
+                                           units.feet_to_meters(filtered[3]))
             self.assertTrue(tag not in kml.kml())
 
         for coord in coordinates:
-            tag = self.coord_format.format(coord[1], coord[0],
-                                           units.feet_to_meters(coord[2]))
+            tag = self.coord_format.format(coord[2], coord[1],
+                                           units.feet_to_meters(coord[3]))
             self.assertTrue(tag in kml.kml())

--- a/server/auvsi_suas/views/auvsi_admin/export_kml.py
+++ b/server/auvsi_suas/views/auvsi_admin/export_kml.py
@@ -30,7 +30,7 @@ class ExportKml(View):
                 logs=UasTelemetry.by_user(user),
                 kml=kml_teams,
                 kml_doc=kml.document)
-        MissionConfig.kml_all(kml_mission)
+        MissionConfig.kml_all(kml_mission, kml.document)
         kml_flyzone = kml.newfolder(name='Fly Zones')
         FlyZone.kml_all(kml_flyzone)
 

--- a/server/auvsi_suas/views/auvsi_admin/live_kml.py
+++ b/server/auvsi_suas/views/auvsi_admin/live_kml.py
@@ -32,7 +32,7 @@ class LiveKml(View):
         (mission, err) = active_mission()
         if err:
             return err
-        MissionConfig.kml_all(kml_mission, [mission])
+        MissionConfig.kml_all(kml_mission, kml.document, [mission])
 
         kml_flyzone = kml.newfolder(name='Fly Zones')
         FlyZone.kml_all(kml_flyzone)

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -271,6 +271,3 @@ OPERATIONAL_WEIGHT = 0.1
 MAX_AIRSPEED_FT_PER_SEC = 118.147
 # Maximum interval between telemetry logs allowed for interpolation.
 MAX_TELMETRY_INTERPOLATE_INTERVAL_SEC = 1.5
-# We should sample moving obstacle position at this time interval when
-# interpolating.
-MOVING_OBSTACLE_INTERPOLATION_INTERVAL = 0.1


### PR DESCRIPTION
Waypoints were from telemetry line to point and stationary obstacles
were based on calculated intersection with cylinder. Moving obstacles
calculation should not have changed.

Fixes bug where stationary obstacle collision doesn't handle case where
line intersection does not imply line segment intersection. Adds
regression test case for such.

Refactors KML to prevent circular dependency. Moving obstacles now
render their own KML folder and aren't tied to teams. To save dev time
in this time-constrained moment, removed proximity markup for KML and
added a TODO note to put it back as part of #311.

Tested with sample data provided in #316 and verified correct reporting
of stationary hits. Note that it appears interpolation of moving
obstacles has changed slightly, as obstacle 3 now reports not hit.
Looking at original KML provided with proximity information, it was
close as to whether it was actually hit. Relying on unit/regression
tests and assuming it was an edge case for discrete interpolation.

Fixes #314 and #316.