### PR TITLE
Remove sudo requirement from Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 dist: trusty
 language: generic
 


### PR DESCRIPTION
This should move us to the default Travis environment, which is
containerized and improves performance/boot-time.

For #322 