### PR TITLE
Tag the Docker image with date during deploy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
 deploy:
   # Push master branch docker images to dockerhub.
   provider: script
-  script: docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" && docker push auvsisuas/interop-server && docker push auvsisuas/interop-client
+  script: bash tools/deploy.sh
   skip_cleanup: true
   on:
     branch: master

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Deploys Docker containers to hub.
+
+set -e
+TOOLS=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
+source ${SETUP}/common.sh
+
+
+log "Tagging Docker images."
+DATE=$(date '+%Y.%m')
+docker tag auvsisuas/interop-client:latest auvsisuas/interop-client:${DATE}
+docker tag auvsisuas/interop-server:latest auvsisuas/interop-server:${DATE}
+
+log "Logging into Docker."
+docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+
+log "Pushing Docker images."
+docker push auvsisuas/interop-server
+docker push auvsisuas/interop-client


### PR DESCRIPTION
Allows teams to upgrade server versions when desired and not always when
there's a git push.

Fixes #339 