### PR TITLE
Remove analysis not used in scoring.

### DIFF
--- a/server/auvsi_suas/models/mission_evaluation_test.py
+++ b/server/auvsi_suas/models/mission_evaluation_test.py
@@ -16,12 +16,8 @@ class TestMissionScoring(TestCase):
         self.eval = mission_pb2.MissionEvaluation()
         self.eval.team = 'team'
         feedback = self.eval.feedback
-        feedback.mission_clock_time_sec = 60 * 10
-        feedback.flight_time_sec = 60 * 4
         feedback.uas_telemetry_time_max_sec = 1.0
         feedback.uas_telemetry_time_avg_sec = 1.0
-        feedback.out_of_bounds_time_sec = 10
-        feedback.boundary_violations = 2
         wpt = feedback.waypoints.add()
         wpt.score_ratio = 0.5
         wpt = feedback.waypoints.add()
@@ -215,12 +211,8 @@ class TestMissionScoring(TestCase):
         self.eval = mission_pb2.MissionEvaluation()
         self.eval.team = 'team'
         feedback = self.eval.feedback
-        feedback.mission_clock_time_sec = 60 * 100
-        feedback.flight_time_sec = 60 * 100
         feedback.uas_telemetry_time_max_sec = 100.0
         feedback.uas_telemetry_time_avg_sec = 100.0
-        feedback.out_of_bounds_time_sec = 60 * 100
-        feedback.boundary_violations = 10
         wpt = feedback.waypoints.add()
         wpt.score_ratio = 0
         wpt = feedback.waypoints.add()
@@ -285,9 +277,6 @@ class TestMissionEvaluation(TestCase):
         self.assertEqual(1.0, feedback.waypoints[0].score_ratio)
         self.assertEqual(0.0,
                          feedback.waypoints[1].closest_for_scored_approach_ft)
-        self.assertAlmostEqual(2, feedback.mission_clock_time_sec)
-        self.assertAlmostEqual(1, feedback.flight_time_sec)
-        self.assertAlmostEqual(0.6, feedback.out_of_bounds_time_sec)
 
         self.assertAlmostEqual(0.5, feedback.uas_telemetry_time_max_sec)
         self.assertAlmostEqual(1. / 6, feedback.uas_telemetry_time_avg_sec)
@@ -344,9 +333,6 @@ class TestMissionEvaluation(TestCase):
         self.assertEqual(1.0, feedback.waypoints[0].score_ratio)
         self.assertEqual(0.0,
                          feedback.waypoints[1].closest_for_scored_approach_ft)
-        self.assertAlmostEqual(18, feedback.mission_clock_time_sec)
-        self.assertAlmostEqual(4, feedback.flight_time_sec)
-        self.assertAlmostEqual(1.0, feedback.out_of_bounds_time_sec)
 
         self.assertAlmostEqual(2.0, feedback.uas_telemetry_time_max_sec)
         self.assertAlmostEqual(1.0, feedback.uas_telemetry_time_avg_sec)

--- a/server/auvsi_suas/proto/mission.proto
+++ b/server/auvsi_suas/proto/mission.proto
@@ -26,33 +26,23 @@ message MissionEvaluation {
 
 // Data which was basis for score, provided as feedback for the team.
 message MissionFeedback {
-    // Time spent on mission clock (seconds) measured by interop.
-    optional double mission_clock_time_sec = 1;
-    // Time spent in air measured by interop.
-    optional double flight_time_sec = 2;
-
     // Max time between telemetry uploads (seconds).
-    optional double uas_telemetry_time_max_sec = 3;
+    optional double uas_telemetry_time_max_sec = 1;
     // Avg time between telemetry uploads (seconds).
-    optional double uas_telemetry_time_avg_sec = 4;
-
-    // Time spent out of bounds (seconds).
-    optional double out_of_bounds_time_sec = 5;
-    // Number of boundary violations.
-    optional int32 boundary_violations = 6;
+    optional double uas_telemetry_time_avg_sec = 2;
 
     // Waypoint evaluation data.
-    repeated WaypointEvaluation waypoints = 7;
+    repeated WaypointEvaluation waypoints = 3;
 
     // Obstacle evaluation data.
-    repeated ObstacleEvaluation stationary_obstacles = 8;
-    repeated ObstacleEvaluation moving_obstacles = 9;
+    repeated ObstacleEvaluation stationary_obstacles = 4;
+    repeated ObstacleEvaluation moving_obstacles = 5;
 
     // Object detection evaluation data.
-    optional MultiOdlcEvaluation odlc = 10;
+    optional MultiOdlcEvaluation odlc = 6;
 
     // Feedback from judges.
-    optional MissionJudgeFeedback judge = 11;
+    optional MissionJudgeFeedback judge = 7;
 }
 
 // Data provided manually by the judges.

--- a/server/auvsi_suas/views/auvsi_admin/evaluate_teams_test.py
+++ b/server/auvsi_suas/views/auvsi_admin/evaluate_teams_test.py
@@ -74,7 +74,7 @@ class TestEvaluateTeams(TestCase):
         self.assertEqual(len(teams), 3)
         self.assertEqual('user0', teams[1]['team'])
         self.assertEqual('user1', teams[2]['team'])
-        self.assertIn('missionClockTimeSec', teams[0]['feedback'])
+        self.assertIn('waypoints', teams[0]['feedback'])
 
     def test_evaluate_teams_specific_team(self):
         """Tests the eval Json method on a specific team."""
@@ -99,6 +99,6 @@ class TestEvaluateTeams(TestCase):
         csv_data = self.load_csv(response)
         self.assertEqual(len(csv_data.split('\n')), 5)
         self.assertIn('team', csv_data)
-        self.assertIn('missionClockTimeSec', csv_data)
+        self.assertIn('waypoints', csv_data)
         self.assertIn('user0', csv_data)
         self.assertIn('user1', csv_data)


### PR DESCRIPTION
Simplifies the code base and removes confusion from conflicting interop
analysis and judge feedback.

Out of bounds is noisy due to handling of takeoff/landing regions, and
prevents us from having to create extra fly zones covering the area
around the takeoff zone which confused teams.

Mission time is perfectly accurate at the lead judge (e.g. sees the team
enter/leave runway), but interop operator usually gets delayed
information, usually leading to conflicting values.

Fixes #343