### PR TITLE
Set the server timezone to New York.

### DIFF
--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -147,7 +147,7 @@ LOGGING = {
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/
 LANGUAGE_CODE = 'en-us'
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'America/New_York'
 USE_I18N = True
 USE_L10N = True
 USE_TZ = True


### PR DESCRIPTION
The New York timezone is the competition timezone. This will make admin
displays which show times intuitive (e.g. Django admin page for
TakeoffOrLandingEvent). UTC is unlikely to be a better default for
display. Django always stores datetime as UTC in the database.