### PR TITLE
Fixed client library setup.py file

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -1,13 +1,9 @@
 from codecs import open
 from setuptools import setup
 
-with open('README.md', encoding='utf-8') as f:
-    readme = f.read()
-
 setup(
     name='interop',
     description='AUVSI SUAS interoperability client library.',
-    long_description=readme,
     license='Apache 2.0',
     packages=['interop'],
 )  # yapf: disable


### PR DESCRIPTION
I was trying to install the interop client through a requirements.txt file using this line:
`git+https://github.com/auvsi-suas/interop.git#egg=interop&subdirectory=client`

When client/setup.py was run python would error out saying it couldn't find the "README.md" file. Sure enough that file was delete in a [commit](https://github.com/auvsi-suas/interop/commit/8ba72b2a5c7df0a1dde4888c24ce653f8b389a10#diff-2) about a month ago.