### PR TITLE
Use setup.py to configure client container.

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -23,21 +23,28 @@ RUN apt-get -qq update && apt-get -qq install -y \
         python3-lxml \
         sudo
 
-COPY client/requirements.txt requirements.txt
-RUN bash -c "virtualenv --system-site-packages -p /usr/bin/python2 \
-            /interop/client/venv2 && \
-        source /interop/client/venv2/bin/activate && \
+COPY client/requirements.txt .
+
+RUN bash -c "cd /interop/client && \
+        virtualenv --system-site-packages -p /usr/bin/python2 venv2 && \
+        source venv2/bin/activate && \
         pip install -r requirements.txt && \
         deactivate" && \
-    bash -c "virtualenv --system-site-packages -p /usr/bin/python3 \
-            /interop/client/venv3 && \
-        source /interop/client/venv3/bin/activate && \
+    bash -c "cd /interop/client && \
+        virtualenv --system-site-packages -p /usr/bin/python3 venv3 && \
+        source venv3/bin/activate && \
         pip3 install -r requirements.txt && \
         deactivate"
 
+COPY proto/ ../proto
 COPY client/ .
-
-COPY proto auvsi_suas/proto
-RUN protoc --python_out=. auvsi_suas/proto/*.proto
+RUN bash -c "cd /interop/client && \
+        source venv2/bin/activate && \
+        python setup.py install && \
+        deactivate" && \
+    bash -c "cd /interop/client && \
+        source venv3/bin/activate && \
+        python3 setup.py install && \
+        deactivate"
 
 CMD bash --init-file configure.sh

--- a/client/setup.py
+++ b/client/setup.py
@@ -14,17 +14,16 @@ class build_py(_build_py):
         if not protoc:
             sys.stderr.write('Cant find protoc.\n')
             sys.exit(-1)
-        if os.path.exists('auvsi_suas/proto'):
-            shutil.rmtree('auvsi_suas/proto')
-        shutil.copytree('../proto', 'auvsi_suas/proto')
+        if not os.path.exists('auvsi_suas/proto'):
+            shutil.copytree('../proto', 'auvsi_suas/proto')
         for (dirpath, dirnames, filenames) in os.walk("auvsi_suas/proto"):
             for filename in filenames:
+                if not filename.endswith(".proto"):
+                    continue
                 filepath = os.path.join(dirpath, filename)
-                if filepath.endswith(".proto"):
-                    if subprocess.call(
-                        [protoc, '-I.', '--python_out=.', filepath]) != 0:
-                        sys.stderr.write('Failed to compile protos.\n')
-                        sys.exit(-1)
+                if subprocess.call([protoc, '--python_out=.', filepath]) != 0:
+                    sys.stderr.write('Failed to compile protos.\n')
+                    sys.exit(-1)
 
         _build_py.run(self)
 
@@ -37,10 +36,15 @@ class clean(_clean):
 
 
 if __name__ == '__main__':
+    reqs = []
+    with open('requirements.txt', 'r') as f:
+        reqs = f.readlines()
+
     setuptools.setup(
         name='auvsi_suas',
         description='AUVSI SUAS interoperability client library.',
         license='Apache 2.0',
         packages=['auvsi_suas'],
         cmdclass = { 'clean': clean, 'build_py': build_py },
+        install_requires=reqs,
     )  # yapf: disable

--- a/client/test.sh
+++ b/client/test.sh
@@ -4,23 +4,6 @@
 set -e
 CLIENT=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 
-# Test install with setuptools.
-(cd ${CLIENT} &&
- virtualenv --system-site-packages -p /usr/bin/python2 test-venv2 && \
- source test-venv2/bin/activate && \
- python setup.py install && \
- python setup.py test && \
- python setup.py clean && \
- deactivate)
-(cd ${CLIENT} &&
- virtualenv --system-site-packages -p /usr/bin/python3 test-venv3 && \
- source test-venv3/bin/activate && \
- python3 setup.py install && \
- python3 setup.py test && \
- python3 setup.py clean && \
- deactivate)
-
-# Test the containers.
 docker run --net="host" -it auvsisuas/interop-client bash -c \
     "export PYTHONPATH=/interop/client && \
      cd /interop/client && \


### PR DESCRIPTION
Improves local testing experience (doesn't litter build files) and improves testing coverage.