### PR TITLE
Require mission ID in request for mission details.

### DIFF
--- a/client/auvsi_suas/client/client.py
+++ b/client/auvsi_suas/client/client.py
@@ -118,23 +118,20 @@ class Client(object):
             raise InteropError(r)
         return r
 
-    def get_missions(self):
-        """GET missions.
+    def get_mission(self, mission_id):
+        """GET a mission by ID.
 
         Returns:
-            List of Mission.
+            Mission.
         Raises:
             InteropError: Error from server.
             requests.Timeout: Request timeout.
             ValueError or AttributeError: Malformed response from server.
         """
-        r = self.get('/api/missions')
-        missions = []
-        for mission_dict in r.json():
-            mission_proto = interop_api_pb2.Mission()
-            json_format.Parse(json.dumps(mission_dict), mission_proto)
-            missions.append(mission_proto)
-        return missions
+        r = self.get('/api/missions/%d' % mission_id)
+        mission = interop_api_pb2.Mission()
+        json_format.Parse(r.text, mission)
+        return mission
 
     def post_telemetry(self, telem):
         """POST new telemetry.
@@ -329,14 +326,14 @@ class AsyncClient(object):
                              max_retries)
         self.executor = ThreadPoolExecutor(max_workers=max_concurrent)
 
-    def get_missions(self):
-        """GET missions.
+    def get_mission(self, mission_id):
+        """GET a mission by ID.
 
         Returns:
             Future object which contains the return value or error from the
             underlying Client.
         """
-        return self.executor.submit(self.client.get_missions)
+        return self.executor.submit(self.client.get_mission, mission_id)
 
     def post_telemetry(self, telem):
         """POST new telemetry.

--- a/client/auvsi_suas/client/client_test.py
+++ b/client/auvsi_suas/client/client_test.py
@@ -59,17 +59,14 @@ class TestClient(unittest.TestCase):
         self.client = Client(server, username, password)
         self.async_client = AsyncClient(server, username, password)
 
-    def test_get_missions(self):
-        """Test getting missions."""
-        missions = self.client.get_missions()
-        async_missions = self.async_client.get_missions().result()
+    def test_get_mission(self):
+        """Test getting a mission."""
+        mission = self.client.get_mission(1)
+        async_mission = self.async_client.get_mission(1).result()
 
-        # Check one mission returned.
-        self.assertEqual(1, len(missions))
-        self.assertEqual(1, len(async_missions))
-        # Check a few fields.
-        self.assertEqual(1, missions[0].id)
-        self.assertEqual(1, async_missions[0].id)
+        # Check basic field info.
+        self.assertEqual(1, mission.id)
+        self.assertEqual(1, async_mission.id)
 
     def test_post_telemetry(self):
         """Test sending some telemetry."""

--- a/client/tools/interop_cli.py
+++ b/client/tools/interop_cli.py
@@ -18,10 +18,9 @@ from upload_odlcs import upload_odlcs
 logger = logging.getLogger(__name__)
 
 
-def missions(args, client):
-    missions = client.get_missions().result()
-    for m in missions:
-        print(json_format.MessageToJson(m))
+def mission(args, client):
+    mission = client.get_mission(args.mission_id).result()
+    print(json_format.MessageToJson(mission))
 
 
 def obstacles(args, client):
@@ -83,8 +82,13 @@ def main():
 
     subparsers = parser.add_subparsers(help='Sub-command help.')
 
-    subparser = subparsers.add_parser('missions', help='Get missions.')
-    subparser.set_defaults(func=missions)
+    subparser = subparsers.add_parser('mission', help='Get mission details.')
+    subparser.set_defaults(func=mission)
+    subparser.add_argument(
+        '--mission_id',
+        type=int,
+        required=True,
+        help='ID of the mission to get.')
 
     subparser = subparsers.add_parser('obstacles', help='Get obstaclesj.')
     subparser.set_defaults(func=obstacles)

--- a/client/tools/interop_cli_test.py
+++ b/client/tools/interop_cli_test.py
@@ -25,9 +25,9 @@ class InteropCliTestBase(unittest.TestCase):
 class TestMissions(InteropCliTestBase):
     """Test able to request mission details."""
 
-    def test_get_missions(self):
+    def test_get_mission(self):
         """Test getting mission details."""
-        self.assertCliOk(self.cli_base_args + ['missions'])
+        self.assertCliOk(self.cli_base_args + ['mission', '--mission_id', '1'])
 
 
 class TestObstacles(InteropCliTestBase):

--- a/server/auvsi_suas/views/missions.py
+++ b/server/auvsi_suas/views/missions.py
@@ -120,9 +120,9 @@ def mission_proto(mission):
 
 
 class Missions(View):
-    """Handles requests for all missions."""
+    """Handles requests for all missions for admins."""
 
-    @method_decorator(require_login)
+    @method_decorator(require_superuser)
     def dispatch(self, *args, **kwargs):
         return super(Missions, self).dispatch(*args, **kwargs)
 


### PR DESCRIPTION
Updates API to get all missions to be admin only, requiring all teams to
specify the mission ID to request details. The competition is moving to
multiple simultaneous missions, so now the list of missions may have
more than one. To prevent likely bugs like always selecting the first in
the list, we force teams to provide the ID of their mission.

Updates client library and CLI to reflect this change.

Fixes #379 