### PR TITLE
Fix missing shape color field on ODLC review.

### DIFF
--- a/server/auvsi_suas/frontend/pages/odlc-review-controller.js
+++ b/server/auvsi_suas/frontend/pages/odlc-review-controller.js
@@ -115,7 +115,7 @@ OdlcReviewCtrl.prototype.setReviewOdlc = function(odlcReview) {
             {'key': 'Alpha',
              'value': this.odlcReview_.odlc.alphanumeric},
             {'key': 'Shape Color',
-             'value': this.odlcReview_.odlc.backgroundColor},
+             'value': this.odlcReview_.odlc.shapeColor},
             {'key': 'Shape',
              'value': this.odlcReview_.odlc.shape}
         ]);


### PR DESCRIPTION
Testing our integration with the new proto-based api, I was afraid we did something wrong when I checked the ODLC review screen and saw no shape color:

![Screenshot_2019-04-19_01-50-23](https://user-images.githubusercontent.com/4411471/56430751-565b8b80-6295-11e9-92c9-55e8cb7b0f41.png)

Turns out the issue was actually with the interop server.