### PR TITLE
Fix single-team eval field names. Fix dash perf.

### DIFF
--- a/proto/interop_admin_api.proto
+++ b/proto/interop_admin_api.proto
@@ -6,17 +6,20 @@ import "auvsi_suas/proto/interop_api.proto";
 
 // Status of a team.
 message TeamStatus {
+    // ID of the team.
+    optional int32 id = 1;
+
     // The team this status describes.
-    optional string team = 1;
+    optional string team = 2;
 
     // Whether the team is marked in air by admin.
-    optional bool in_air = 2;
+    optional bool in_air = 3;
 
     // Most recent telemetry position, if it exists.
-    optional Telemetry telemetry = 3;
+    optional Telemetry telemetry = 4;
 
     // Timestamp of the telemetry position as ISO string.
-    optional string telemetry_timestamp = 4;
+    optional string telemetry_timestamp = 5;
 }
 
 // Review details for an ODLC.

--- a/server/auvsi_suas/frontend/pages/evaluate-teams.html
+++ b/server/auvsi_suas/frontend/pages/evaluate-teams.html
@@ -10,7 +10,7 @@
             Team
             <select ng-model="evaluateTeamsCtrl.selectedTeamId">
                 <option value=-1>All</option>
-                <option ng-repeat="t in evaluateTeamsCtrl.teams | orderBy: 'name'" ng-value="t.id">{{t.name}}</option>
+                <option ng-repeat="t in evaluateTeamsCtrl.teams | orderBy: 'team'" ng-value="t.id">{{t.team}}</option>
             </select>
         </label>
         <button type="button" class="success button" ng-click="evaluateTeamsCtrl.evaluate()">Evaluate</button>

--- a/server/auvsi_suas/frontend/pages/mission-dashboard-controller.js
+++ b/server/auvsi_suas/frontend/pages/mission-dashboard-controller.js
@@ -5,16 +5,16 @@
 
 /**
  * Controller for the Mission Dashboard page.
- * @param {!angular.Scope} $rootScope The root scope to listen for events.
  * @param {!angular.$routeParams} $routeParams The route parameter service.
  * @param {!angular.$interval} $interval The interval service.
+ * @param {!angular.Scope} $scope The scope of the controller to listen for events.
  * @param {!Object} Backend The backend service.
  * @final
  * @constructor
  * @struct
  * @ngInject
  */
-MissionDashboardCtrl = function($rootScope, $routeParams, $interval, Backend) {
+MissionDashboardCtrl = function($routeParams, $interval, $scope, Backend) {
     /**
      * @export {?Object} The teams data.
      */
@@ -26,6 +26,11 @@ MissionDashboardCtrl = function($rootScope, $routeParams, $interval, Backend) {
     this.routeParams_ = $routeParams;
 
     /**
+     * @private {!angular.$interval} $interval The interval service.
+     */
+    this.interval_ = $interval;
+
+    /**
      * @private @const {!Object} The backend service.
      */
     this.backend_ = Backend;
@@ -33,8 +38,12 @@ MissionDashboardCtrl = function($rootScope, $routeParams, $interval, Backend) {
     /**
      * @private @const {!Object} Data sync every 1s.
      */
-    this.updateInterval_ = $interval(
+    this.updateInterval_ = this.interval_(
             angular.bind(this, this.update_), 1000);
+    $scope.$on("$destroy", angular.bind(this, function() {
+        this.interval_.cancel(this.updateInterval_);
+        this.updateInterval_ = null;
+    }));
 };
 
 /**
@@ -59,9 +68,9 @@ MissionDashboardCtrl.prototype.setTeams_ = function(teams) {
 
 // Register controller with app.
 angular.module('auvsiSuasApp').controller('MissionDashboardCtrl', [
-    '$rootScope',
     '$routeParams',
     '$interval',
+    '$scope',
     'Backend',
     MissionDashboardCtrl
 ]);

--- a/server/auvsi_suas/views/teams.py
+++ b/server/auvsi_suas/views/teams.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 def team_proto(user):
     """Generate TeamStatus proto for team."""
     team_status_proto = interop_admin_api_pb2.TeamStatus()
+    team_status_proto.id = user.pk
     team_status_proto.team = user.username
     team_status_proto.in_air = TakeoffOrLandingEvent.user_in_air(user)
 

--- a/server/auvsi_suas/views/teams_test.py
+++ b/server/auvsi_suas/views/teams_test.py
@@ -103,6 +103,7 @@ class TestTeamsView(TestCase):
         self.assertEqual(2, len(data))
 
         for user in data:
+            self.assertIn('id', user)
             self.assertIn('team', user)
             self.assertIn('inAir', user)
             if 'telemetry' in user:


### PR DESCRIPTION
Single team eval was broken by the proto change when field names were
changed. This fixes the field naming and adds back the id field.

Fixes a performance issue in the dashboard where intervals weren't
stopped on page change and new intervals would be created on navigation
back. This would cause N intervals to be running, growing load on the
server by N times. Now the controller listens for destroy and cancels
the interval.