### PR TITLE
Make safety pilot takeover a section level penalty.

### DIFF
--- a/proto/interop_admin_api.proto
+++ b/proto/interop_admin_api.proto
@@ -207,9 +207,10 @@ message AutonomousFlightScore {
     optional double flight = 3;
     optional double waypoint_capture = 4;
     optional double waypoint_accuracy = 5;
-    optional double out_of_bounds_penalty = 6;
-    optional double things_fell_off_penalty = 7;
-    optional double crashed_penalty = 8;
+    optional double safety_pilot_takeover_penalty = 6;
+    optional double out_of_bounds_penalty = 7;
+    optional double things_fell_off_penalty = 8;
+    optional double crashed_penalty = 9;
 }
 
 // Scoring data for obstacle avoidance.

--- a/server/auvsi_suas/models/mission_evaluation.py
+++ b/server/auvsi_suas/models/mission_evaluation.py
@@ -152,11 +152,7 @@ def score_team(team_eval):
 
     # Score autonomous flight.
     flight = score.autonomous_flight
-    if feedback.judge.min_auto_flight_time:
-        takeovers = feedback.judge.safety_pilot_takeovers
-        flight.flight = max(0, 1 - (takeovers * AUTONOMOUS_FLIGHT_TAKEOVER))
-    else:
-        flight.flight = 0
+    flight.flight = 1 if feedback.judge.min_auto_flight_time else 0
     flight.telemetry_prerequisite = telem_prereq
     flight.waypoint_capture = (
         float(feedback.judge.waypoints_captured) / len(feedback.waypoints))
@@ -165,6 +161,7 @@ def score_team(team_eval):
         flight.waypoint_accuracy = sum(wpt_scores) / len(feedback.waypoints)
     else:
         flight.waypoint_accuracy = 0
+    flight.safety_pilot_takeover_penalty = AUTONOMOUS_FLIGHT_TAKEOVER * feedback.judge.safety_pilot_takeovers
     flight.out_of_bounds_penalty = (
         feedback.judge.out_of_bounds * BOUND_PENALTY +
         feedback.judge.unsafe_out_of_bounds * SAFETY_BOUND_PENALTY)
@@ -180,8 +177,8 @@ def score_team(team_eval):
         AUTONOMOUS_FLIGHT_FLIGHT_WEIGHT * flight.flight +
         WAYPOINT_CAPTURE_WEIGHT * flight.waypoint_capture +
         WAYPOINT_ACCURACY_WEIGHT * flight.waypoint_accuracy -
-        flight.out_of_bounds_penalty - flight.things_fell_off_penalty -
-        flight.crashed_penalty)
+        flight.safety_pilot_takeover_penalty - flight.out_of_bounds_penalty -
+        flight.things_fell_off_penalty - flight.crashed_penalty)
 
     # Score obstacle avoidance.
     avoid = score.obstacle_avoidance

--- a/server/auvsi_suas/models/mission_evaluation_test.py
+++ b/server/auvsi_suas/models/mission_evaluation_test.py
@@ -82,13 +82,14 @@ class TestMissionScoring(TestCase):
 
         mission_evaluation.score_team(self.eval)
         self.assertTrue(flight.telemetry_prerequisite)
-        self.assertAlmostEqual(0.8, flight.flight)
+        self.assertAlmostEqual(1, flight.flight)
         self.assertAlmostEqual(1, flight.waypoint_capture)
         self.assertAlmostEqual(0.35, flight.waypoint_accuracy)
+        self.assertAlmostEqual(0.2, flight.safety_pilot_takeover_penalty)
         self.assertAlmostEqual(0.3, flight.out_of_bounds_penalty)
         self.assertEqual(0, flight.things_fell_off_penalty)
         self.assertEqual(0, flight.crashed_penalty)
-        self.assertAlmostEqual(0.295, flight.score_ratio)
+        self.assertAlmostEqual(0.175, flight.score_ratio)
 
         feedback.waypoints[1].score_ratio = 1
         judge.waypoints_captured = 1
@@ -99,6 +100,7 @@ class TestMissionScoring(TestCase):
         self.assertAlmostEqual(1, flight.flight)
         self.assertAlmostEqual(0.5, flight.waypoint_capture)
         self.assertAlmostEqual(0.75, flight.waypoint_accuracy)
+        self.assertAlmostEqual(0, flight.safety_pilot_takeover_penalty)
         self.assertAlmostEqual(0, flight.out_of_bounds_penalty)
         self.assertAlmostEqual(0.825, flight.score_ratio)
 
@@ -193,7 +195,7 @@ class TestMissionScoring(TestCase):
     def test_total(self):
         """Test the total scoring."""
         mission_evaluation.score_team(self.eval)
-        self.assertAlmostEqual(0.4300777777777778, self.eval.score.score_ratio)
+        self.assertAlmostEqual(0.3940777777777778, self.eval.score.score_ratio)
 
     def test_non_negative(self):
         """Test that total score doesn't go negative."""
@@ -330,15 +332,17 @@ class TestMissionEvaluation(TestCase):
         self.assertAlmostEqual(0, score.timeline.mission_penalty)
         self.assertAlmostEqual(0, score.timeline.timeout)
         self.assertAlmostEqual(0.79934815, score.timeline.score_ratio)
-        self.assertAlmostEqual(0.9, score.autonomous_flight.flight)
+        self.assertAlmostEqual(1, score.autonomous_flight.flight)
         self.assertAlmostEqual(0.5, score.autonomous_flight.waypoint_capture)
         self.assertAlmostEqual(1, score.autonomous_flight.waypoint_accuracy)
+        self.assertAlmostEqual(
+            0.1, score.autonomous_flight.safety_pilot_takeover_penalty)
         self.assertAlmostEqual(0,
                                score.autonomous_flight.out_of_bounds_penalty)
         self.assertAlmostEqual(0.25,
                                score.autonomous_flight.things_fell_off_penalty)
         self.assertAlmostEqual(0.35, score.autonomous_flight.crashed_penalty)
-        self.assertAlmostEqual(0.31, score.autonomous_flight.score_ratio)
+        self.assertAlmostEqual(0.25, score.autonomous_flight.score_ratio)
 
         self.assertAlmostEqual(0, score.object.characteristics)
         self.assertAlmostEqual(0, score.object.geolocation)
@@ -352,7 +356,7 @@ class TestMissionEvaluation(TestCase):
 
         self.assertAlmostEqual(0.8, score.operational_excellence.score_ratio)
 
-        self.assertAlmostEqual(0.5462681481481482, score.score_ratio)
+        self.assertAlmostEqual(0.5282681481481482, score.score_ratio)
 
     def test_evaluate_teams_specific_users(self):
         """Tests the evaluation of teams method with specific users."""


### PR DESCRIPTION
This makes the penalty structure parallel, rather than having a special
case for scoring takeovers. This was part of a rule update mid-year.
Also increases the weighting of manual flight takeovers.

Fixes #382 