### PR TITLE
Return HTTP 400 rather than 500 for wrong mission.

### DIFF
--- a/server/auvsi_suas/views/odlcs.py
+++ b/server/auvsi_suas/views/odlcs.py
@@ -6,6 +6,7 @@ import logging
 import os
 import os.path
 from auvsi_suas.models.gps_position import GpsPosition
+from auvsi_suas.models.mission_config import MissionConfig
 from auvsi_suas.models.odlc import Odlc
 from auvsi_suas.proto import interop_admin_api_pb2
 from auvsi_suas.proto import interop_api_pb2
@@ -55,6 +56,11 @@ def validate_odlc_proto(odlc_proto):
     """Validates ODLC proto, raising ValueError if invalid."""
     if not odlc_proto.HasField('mission'):
         raise ValueError('ODLC mission is required.')
+
+    try:
+        MissionConfig.objects.get(pk=odlc_proto.mission)
+    except MissionConfig.DoesNotExist:
+        raise ValueError('Mission for ODLC does not exist.')
 
     if not odlc_proto.HasField('type'):
         raise ValueError('ODLC type is required.')

--- a/server/auvsi_suas/views/odlcs_test.py
+++ b/server/auvsi_suas/views/odlcs_test.py
@@ -284,6 +284,17 @@ class TestPostOdlc(TestOdlcsCommon):
             content_type='multipart/form-data')
         self.assertEqual(400, response.status_code)
 
+    def test_invalid_mission(self):
+        """Mission ID must correspond to an actual mission."""
+        odlc = {
+            'mission': self.mission2.pk + 1,
+            'type': 'STANDARD',
+        }
+
+        response = self.client.post(
+            odlcs_url, data=json.dumps(odlc), content_type='application/json')
+        self.assertEqual(400, response.status_code)
+
     def test_missing_latitude(self):
         """Odlc latitude required if longitude specified."""
         odlc = {


### PR DESCRIPTION
Detects when the mission ID for an ODLC submission doesn't correspond to
a valid mission.