### PR TITLE
Add basic db validation of fields.

### DIFF
--- a/server/auvsi_suas/models/aerial_position.py
+++ b/server/auvsi_suas/models/aerial_position.py
@@ -4,17 +4,26 @@ import logging
 from auvsi_suas.models import distance
 from auvsi_suas.models.gps_position import GpsPosition
 from django.contrib import admin
+from django.core import validators
 from django.db import models
 
 logger = logging.getLogger(__name__)
+
+ALTITUDE_MSL_FT_MIN = -2000  # Lowest point on earth with buffer.
+ALTITUDE_MSL_FT_MAX = 396000  # Edge of atmosphere.
+ALTITUDE_VALIDATORS = [
+    validators.MinValueValidator(ALTITUDE_MSL_FT_MIN),
+    validators.MaxValueValidator(ALTITUDE_MSL_FT_MAX),
+]
 
 
 class AerialPosition(models.Model):
     """Aerial position which consists of a GPS position and an altitude."""
     # GPS position.
     gps_position = models.ForeignKey(GpsPosition, on_delete=models.CASCADE)
+
     # Altitude (MSL) in feet.
-    altitude_msl = models.FloatField()
+    altitude_msl = models.FloatField(validators=ALTITUDE_VALIDATORS)
 
     def distance_to(self, other):
         """Computes distance to another position.
@@ -48,4 +57,4 @@ class AerialPosition(models.Model):
 class AerialPositionModelAdmin(admin.ModelAdmin):
     show_full_result_count = False
     raw_id_fields = ("gps_position", )
-    list_display = ('gps_position', 'altitude_msl')
+    list_display = ('pk', 'gps_position', 'altitude_msl')

--- a/server/auvsi_suas/models/aerial_position_test.py
+++ b/server/auvsi_suas/models/aerial_position_test.py
@@ -27,6 +27,13 @@ class TestAerialPositionModel(TestCase):
 
             self.assertDistanceEqual(pos1, pos2, dist_actual)
 
+    def test_clean(self):
+        """Tests validation."""
+        gps = GpsPosition(latitude=0, longitude=0)
+        gps.save()
+        pos = AerialPosition(gps_position=gps, altitude_msl=0)
+        pos.full_clean()
+
     def test_distance_zero(self):
         """Tests distance calc for same position."""
         self.evaluate_distance_inputs([

--- a/server/auvsi_suas/models/fly_zone_test.py
+++ b/server/auvsi_suas/models/fly_zone_test.py
@@ -204,6 +204,11 @@ class TestFlyZone(TestCase):
             # Store
             self.testdata_containspos.append((zone, test_pos))
 
+    def test_clean(self):
+        """Tests model validation."""
+        for (zone, _) in self.testdata_containspos:
+            zone.full_clean()
+
     def test_contains_pos(self):
         """Tests the contains_pos method."""
         for (zone, test_pos) in self.testdata_containspos:

--- a/server/auvsi_suas/models/gps_position.py
+++ b/server/auvsi_suas/models/gps_position.py
@@ -3,6 +3,7 @@
 import logging
 from auvsi_suas.models import distance
 from django.contrib import admin
+from django.core import validators
 from django.db import models
 
 logger = logging.getLogger(__name__)
@@ -12,9 +13,15 @@ class GpsPosition(models.Model):
     """GPS position consisting of a latitude and longitude degree value."""
 
     # Latitude in degrees.
-    latitude = models.FloatField()
+    latitude = models.FloatField(validators=[
+        validators.MinValueValidator(-90),
+        validators.MaxValueValidator(90),
+    ])
     # Longitude in degrees.
-    longitude = models.FloatField()
+    longitude = models.FloatField(validators=[
+        validators.MinValueValidator(-180),
+        validators.MaxValueValidator(180),
+    ])
 
     def distance_to(self, other):
         """Computes distance to another position.
@@ -45,4 +52,4 @@ class GpsPosition(models.Model):
 @admin.register(GpsPosition)
 class GpsPositionModelAdmin(admin.ModelAdmin):
     show_full_result_count = False
-    list_display = ('latitude', 'longitude')
+    list_display = ('pk', 'latitude', 'longitude')

--- a/server/auvsi_suas/models/gps_position_test.py
+++ b/server/auvsi_suas/models/gps_position_test.py
@@ -23,6 +23,11 @@ class TestGpsPositionModel(TestCase):
 
             self.assert_distance_equal(gps1, gps2, dist_actual)
 
+    def test_clean(self):
+        """Tests model validation."""
+        gps = GpsPosition(latitude=0, longitude=0)
+        gps.full_clean()
+
     def test_distance_zero(self):
         """Tests distance calc for same position."""
         self.evaluate_distance_inputs([

--- a/server/auvsi_suas/models/mission_config.py
+++ b/server/auvsi_suas/models/mission_config.py
@@ -7,6 +7,7 @@ from auvsi_suas.models.odlc import Odlc
 from auvsi_suas.models.stationary_obstacle import StationaryObstacle
 from auvsi_suas.models.waypoint import Waypoint
 from django.contrib import admin
+from django.core import validators
 from django.db import models
 
 logger = logging.getLogger(__name__)
@@ -58,4 +59,4 @@ class MissionConfigModelAdmin(admin.ModelAdmin):
                      "off_axis_odlc_pos", "air_drop_pos")
     filter_horizontal = ("fly_zones", "mission_waypoints",
                          "search_grid_points", "odlcs", "stationary_obstacles")
-    list_display = ('home_pos', )
+    list_display = ('pk', 'home_pos', )

--- a/server/auvsi_suas/models/mission_config_test.py
+++ b/server/auvsi_suas/models/mission_config_test.py
@@ -11,3 +11,8 @@ class TestMissionConfigModelSampleMission(TestCase):
     def test_str(self):
         for mission in MissionConfig.objects.all():
             self.assertNotEqual(str(mission), '')
+
+    def test_clean(self):
+        """Test model validation."""
+        for mission in MissionConfig.objects.all():
+            mission.full_clean()

--- a/server/auvsi_suas/models/mission_judge_feedback.py
+++ b/server/auvsi_suas/models/mission_judge_feedback.py
@@ -6,6 +6,7 @@ from auvsi_suas.models.mission_config import MissionConfig
 from auvsi_suas.proto import interop_admin_api_pb2
 from django.conf import settings
 from django.contrib import admin
+from django.core import validators
 from django.db import models
 
 logger = logging.getLogger(__name__)
@@ -29,13 +30,21 @@ class MissionJudgeFeedback(models.Model):
     # Whether the team had the min auto flight time.
     min_auto_flight_time = models.BooleanField()
     # The number of times the pilot took over.
-    safety_pilot_takeovers = models.IntegerField()
+    safety_pilot_takeovers = models.IntegerField(validators=[
+        validators.MinValueValidator(0),
+    ])
     # Number of waypoints that were captured.
-    waypoints_captured = models.IntegerField()
+    waypoints_captured = models.IntegerField(validators=[
+        validators.MinValueValidator(0),
+    ])
     # Number of times the UAS went out of bounds.
-    out_of_bounds = models.IntegerField()
+    out_of_bounds = models.IntegerField(validators=[
+        validators.MinValueValidator(0),
+    ])
     # Number of times out of bounds compromised safety.
-    unsafe_out_of_bounds = models.IntegerField()
+    unsafe_out_of_bounds = models.IntegerField(validators=[
+        validators.MinValueValidator(0),
+    ])
     # Whether something fell off UAS during flight.
     things_fell_off_uas = models.BooleanField()
     # Whether the UAS crashed.
@@ -49,7 +58,10 @@ class MissionJudgeFeedback(models.Model):
     ugv_drove_to_location = models.BooleanField()
 
     # Grade of team performance [0, 100].
-    operational_excellence_percent = models.FloatField()
+    operational_excellence_percent = models.FloatField(validators=[
+        validators.MinValueValidator(0),
+        validators.MaxValueValidator(100),
+    ])
 
     class Meta:
         unique_together = (('mission', 'user'), )
@@ -81,9 +93,10 @@ class MissionJudgeFeedback(models.Model):
 @admin.register(MissionJudgeFeedback)
 class MissionJudgeFeedbackModelAdmin(admin.ModelAdmin):
     show_full_result_count = False
-    list_display = ('mission', 'user', 'flight_time', 'post_process_time',
-                    'used_timeout', 'min_auto_flight_time',
-                    'safety_pilot_takeovers', 'waypoints_captured',
-                    'out_of_bounds', 'unsafe_out_of_bounds',
-                    'things_fell_off_uas', 'crashed', 'air_drop_accuracy',
-                    'ugv_drove_to_location', 'operational_excellence_percent')
+    list_display = ('pk', 'mission', 'user', 'flight_time',
+                    'post_process_time', 'used_timeout',
+                    'min_auto_flight_time', 'safety_pilot_takeovers',
+                    'waypoints_captured', 'out_of_bounds',
+                    'unsafe_out_of_bounds', 'things_fell_off_uas', 'crashed',
+                    'air_drop_accuracy', 'ugv_drove_to_location',
+                    'operational_excellence_percent')

--- a/server/auvsi_suas/models/mission_judge_feedback_test.py
+++ b/server/auvsi_suas/models/mission_judge_feedback_test.py
@@ -56,6 +56,10 @@ class TestMissionJudgeFeedback(TestCase):
             operational_excellence_percent=9)
         self.feedback.save()
 
+    def test_clean(self):
+        """Test model validation."""
+        self.feedback.full_clean()
+
     def test_proto(self):
         """Tests proto()."""
         pb = self.feedback.proto()

--- a/server/auvsi_suas/models/odlc.py
+++ b/server/auvsi_suas/models/odlc.py
@@ -402,7 +402,7 @@ class OdlcEvaluator(object):
 class OdlcModelAdmin(admin.ModelAdmin):
     show_full_result_count = False
     raw_id_fields = ("location", )
-    list_display = ('user', 'odlc_type', 'location', 'orientation', 'shape',
-                    'background_color', 'alphanumeric', 'alphanumeric_color',
-                    'autonomous', 'thumbnail_approved', 'creation_time',
-                    'last_modified_time')
+    list_display = ('pk', 'user', 'odlc_type', 'location', 'orientation',
+                    'shape', 'background_color', 'alphanumeric',
+                    'alphanumeric_color', 'autonomous', 'thumbnail_approved',
+                    'creation_time', 'last_modified_time')

--- a/server/auvsi_suas/models/stationary_obstacle.py
+++ b/server/auvsi_suas/models/stationary_obstacle.py
@@ -4,9 +4,13 @@ import logging
 from auvsi_suas.models.gps_position import GpsPosition
 from auvsi_suas.models.uas_telemetry import UasTelemetry
 from django.contrib import admin
+from django.core import validators
 from django.db import models
 
 logger = logging.getLogger(__name__)
+
+STATIONARY_OBSTACLE_RADIUS_FT_MIN = 30
+STATIONARY_OBSTACLE_RAIDUS_FT_MAX = 300
 
 
 class StationaryObstacle(models.Model):
@@ -15,7 +19,10 @@ class StationaryObstacle(models.Model):
     # The position of the obstacle center.
     gps_position = models.ForeignKey(GpsPosition, on_delete=models.CASCADE)
     # The radius of the cylinder in feet.
-    cylinder_radius = models.FloatField()
+    cylinder_radius = models.FloatField(validators=[
+        validators.MinValueValidator(STATIONARY_OBSTACLE_RADIUS_FT_MIN),
+        validators.MaxValueValidator(STATIONARY_OBSTACLE_RAIDUS_FT_MAX),
+    ])
     # The height of the cylinder in feet.
     cylinder_height = models.FloatField()
 
@@ -54,4 +61,4 @@ class StationaryObstacle(models.Model):
 @admin.register(StationaryObstacle)
 class StationaryObstacleModelAdmin(admin.ModelAdmin):
     raw_id_fields = ("gps_position", )
-    list_display = ('gps_position', 'cylinder_radius', 'cylinder_height')
+    list_display = ('pk', 'gps_position', 'cylinder_radius', 'cylinder_height')

--- a/server/auvsi_suas/models/stationary_obstacle_test.py
+++ b/server/auvsi_suas/models/stationary_obstacle_test.py
@@ -50,6 +50,14 @@ class TestStationaryObstacleModel(TestCase):
 
         return ret
 
+    def test_clean(self):
+        """Tests model validation."""
+        pos = GpsPosition(latitude=0, longitude=0)
+        pos.save()
+        obst = StationaryObstacle(
+            gps_position=pos, cylinder_radius=30, cylinder_height=10)
+        obst.full_clean()
+
     def test_contains_pos(self):
         """Tests the inside obstacle method."""
         # (lat, lon, rad, height)

--- a/server/auvsi_suas/models/takeoff_or_landing_event.py
+++ b/server/auvsi_suas/models/takeoff_or_landing_event.py
@@ -52,4 +52,4 @@ class TakeoffOrLandingEvent(AccessLog):
 @admin.register(TakeoffOrLandingEvent)
 class TakeoffOrLandingEventModelAdmin(admin.ModelAdmin):
     show_full_result_count = False
-    list_display = ('timestamp', 'user', 'mission', 'uas_in_air')
+    list_display = ('pk', 'timestamp', 'user', 'mission', 'uas_in_air')

--- a/server/auvsi_suas/models/uas_telemetry.py
+++ b/server/auvsi_suas/models/uas_telemetry.py
@@ -9,6 +9,7 @@ from auvsi_suas.models.gps_position import GpsPosition
 from auvsi_suas.proto import interop_admin_api_pb2
 from collections import defaultdict
 from django.contrib import admin
+from django.core import validators
 from django.db import models
 
 logger = logging.getLogger(__name__)
@@ -33,7 +34,10 @@ class UasTelemetry(AccessLog):
     # The position of the UAS.
     uas_position = models.ForeignKey(AerialPosition, on_delete=models.CASCADE)
     # The (true north) heading of the UAS in degrees.
-    uas_heading = models.FloatField()
+    uas_heading = models.FloatField(validators=[
+        validators.MinValueValidator(0),
+        validators.MaxValueValidator(360),
+    ])
 
     def duplicate(self, other):
         """Determines whether this UasTelemetry is equivalent to another.
@@ -263,4 +267,4 @@ class UasTelemetry(AccessLog):
 class UasTelemetryModelAdmin(admin.ModelAdmin):
     show_full_result_count = False
     raw_id_fields = ("uas_position", )
-    list_display = ('user', 'timestamp', 'uas_position', 'uas_heading')
+    list_display = ('pk', 'user', 'timestamp', 'uas_position', 'uas_heading')

--- a/server/auvsi_suas/models/uas_telemetry_test.py
+++ b/server/auvsi_suas/models/uas_telemetry_test.py
@@ -157,6 +157,10 @@ class TestUasTelemetry(TestUasTelemetryBase):
         self.log = self.create_log_element(
             timestamp=0, lat=10, lon=100, alt=200, heading=90)
 
+    def test_clean(self):
+        """Tests model validation."""
+        self.log.full_clean()
+
     def test_duplicate_unequal(self):
         """Tests duplicate function with unequal telemetry."""
         log1 = self.create_log_element(

--- a/server/auvsi_suas/models/waypoint.py
+++ b/server/auvsi_suas/models/waypoint.py
@@ -30,4 +30,4 @@ class Waypoint(models.Model):
 class WaypointModelAdmin(admin.ModelAdmin):
     show_full_result_count = False
     raw_id_fields = ("position", )
-    list_display = ('position', 'order')
+    list_display = ('pk', 'position', 'order')


### PR DESCRIPTION
Validates fields using Django's field validator and clean() model
method. This ensures validity of objects created via the administration
form. This does not validate in instances where save() is called, which
is already covered by view code.

Note this does not validate any many-to-many field, a limitation of
Django's framework which cannot access those fields before saving. In
practice, this only limits the min/max count tests (enough points to
define a fly zone polygon, not too many stationary obstacles) and the
max-distance waypoint test.

We'll need a view to handle more advanced validation. For now, this will
suffice.

Fixes #378