### PR TITLE
Add GPS conversion utility page.

### DIFF
--- a/proto/interop_admin_api.proto
+++ b/proto/interop_admin_api.proto
@@ -261,3 +261,18 @@ message AirDropScore {
 message OperationalExcellenceScore {
     optional double score_ratio = 1;
 }
+
+// GPS conversion request.
+// Used to convert GPS positions in string format into decimal format.
+message GpsConversionRequest {
+    // Example: N38-08-46.57
+    optional string latitude = 1;
+    // Example: W076-25-41.39
+    optional string longitude = 2;
+}
+
+// GPS conversion response.
+message GpsConversionResponse {
+    optional double latitude = 1;
+    optional double longitude = 2;
+}

--- a/server/auvsi_suas/frontend/app.js
+++ b/server/auvsi_suas/frontend/app.js
@@ -36,6 +36,11 @@ auvsiSuasApp.config(['$routeProvider', function($routeProvider) {
             controller: 'EvaluateTeamsCtrl',
             controllerAs: 'evaluateTeamsCtrl'
         }).
+        when('/gps_conversion', {
+            templateUrl: '/static/pages/gps-conversion.html',
+            controller: 'GpsConversionCtrl',
+            controllerAs: 'gpsConversionCtrl'
+        }).
         otherwise({
             redirectTo: '/'
         });

--- a/server/auvsi_suas/frontend/components/navigation.js
+++ b/server/auvsi_suas/frontend/components/navigation.js
@@ -32,6 +32,11 @@ NavigationCtrl = function($routeParams) {
             target: "_blank"
         },
         {
+            text: "GPS Conversion",
+            url: "/#!/gps_conversion",
+            target: "_self"
+        },
+        {
             text: "Edit Data",
             url: "/admin",
             target: "_blank"

--- a/server/auvsi_suas/frontend/pages/gps-conversion-controller.js
+++ b/server/auvsi_suas/frontend/pages/gps-conversion-controller.js
@@ -1,0 +1,56 @@
+/**
+ * Controller for the GPS Conversion page.
+ */
+
+/**
+ * Controller for the GPS Conversion page.
+ * @param {!angular.$http} $http The http service.
+ * @final
+ * @construct
+ * @struct
+ * @ngInject
+ */
+GpsConversionCtrl = function($http) {
+    /**
+     * @export {!string} The latitude string.
+     */
+    this.latitudeStr = '';
+
+    /**
+     * @export {!string} The longitude string.
+     */
+    this.longitudeStr = '';
+
+    /**
+     * @export {!number} The latitude converted.
+     */
+    this.latitude = 0;
+
+    /**
+     * @export {!number} The longitude converted.
+     */
+    this.longitude = 0;
+
+    /**
+     * @private {!angular.$http} The http service.
+     */
+    this.http_ = $http;
+};
+
+GpsConversionCtrl.prototype.update = function() {
+    this.http_.post('/api/utils/gps_conversion', {
+        latitude: this.latitudeStr,
+        longitude: this.longitudeStr,
+    }).then(angular.bind(this, this.setConversion_));
+};
+
+GpsConversionCtrl.prototype.setConversion_ = function(response) {
+    this.latitude = response.data.latitude;
+    this.longitude = response.data.longitude;
+};
+
+// Register controller with app.
+angular.module('auvsiSuasApp').controller('GpsConversionCtrl', [
+    '$http',
+    GpsConversionCtrl
+]);

--- a/server/auvsi_suas/frontend/pages/gps-conversion.html
+++ b/server/auvsi_suas/frontend/pages/gps-conversion.html
@@ -1,0 +1,29 @@
+<div class="row p-4">
+    <div class="col-12 text-center">
+        <h4>GPS Conversion</h4>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col text-right">
+        <label>
+            Latitude
+            <input type="text" ng-model="gpsConversionCtrl.latitudeStr"
+                               ng-blur="gpsConversionCtrl.update()"
+                               placeholder="Example: N38-08-46.57">
+            </input>
+        </label></br>
+        {{gpsConversionCtrl.latitude}}
+    </div>
+    <div class="col text-left">
+        <label>
+            Longitude
+            <input type="text" ng-model="gpsConversionCtrl.longitudeStr"
+                               ng-blur="gpsConversionCtrl.update()"
+                               placeholder="Example: W076-25-41.39">
+            </input>
+        </label></br>
+        {{gpsConversionCtrl.longitude}}
+    </div>
+  </div>
+</div>

--- a/server/auvsi_suas/views/urls.py
+++ b/server/auvsi_suas/views/urls.py
@@ -14,6 +14,7 @@ from auvsi_suas.views.odlcs import OdlcsIdImage
 from auvsi_suas.views.teams import Teams
 from auvsi_suas.views.teams import Team
 from auvsi_suas.views.telemetry import Telemetry
+from auvsi_suas.views.utils import GpsConversion
 from django.conf.urls import url
 from django.conf import settings
 from django.conf.urls.static import static
@@ -39,5 +40,6 @@ urlpatterns = [
     url(r'^api/teams$', Teams.as_view(), name='teams'),
     url(r'^api/teams/(?P<username>.+)$', Team.as_view(), name='team'),
     url(r'^api/telemetry$', Telemetry.as_view(), name='telemetry'),
+    url(r'^api/utils/gps_conversion$', GpsConversion.as_view(), name='gps_conversion'),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 # yapf: enable

--- a/server/auvsi_suas/views/utils.py
+++ b/server/auvsi_suas/views/utils.py
@@ -1,0 +1,46 @@
+"""Utilities for admins."""
+
+import json
+import logging
+from LatLon23 import string2latlon
+from auvsi_suas.proto import interop_admin_api_pb2
+from auvsi_suas.views.decorators import require_superuser
+from auvsi_suas.views.json import ProtoJsonEncoder
+from django.http import HttpResponse
+from django.http import HttpResponseBadRequest
+from django.utils.decorators import method_decorator
+from django.views.generic import View
+from google.protobuf import json_format
+
+LATLON_FORMAT = 'H%d%-%m%-%S'
+
+
+class GpsConversion(View):
+    """Converts GPS from string to decimal."""
+
+    @method_decorator(require_superuser)
+    def dispatch(self, *args, **kwargs):
+        return super(GpsConversion, self).dispatch(*args, **kwargs)
+
+    def post(self, request):
+        request_proto = interop_admin_api_pb2.GpsConversionRequest()
+        try:
+            json_format.Parse(request.body, request_proto)
+        except Exception as e:
+            return HttpResponseBadRequest('Failed to parse request. Error: %s' % str(e))
+
+        if not request_proto.HasField('latitude') or not request_proto.HasField('longitude'):
+            return HttpResponseBadRequest('Request missing fields.')
+
+        try:
+            latlon = string2latlon(request_proto.latitude, request_proto.longitude, LATLON_FORMAT)
+        except Exception as e:
+            return HttpResponseBadRequest('Failed to convert GPS. Error: %s' % str(e))
+
+        response = interop_admin_api_pb2.GpsConversionResponse()
+        response.latitude = latlon.lat.decimal_degree
+        response.longitude = latlon.lon.decimal_degree
+
+        return HttpResponse(
+            json_format.MessageToJson(response),
+            content_type="application/json")

--- a/server/auvsi_suas/views/utils_test.py
+++ b/server/auvsi_suas/views/utils_test.py
@@ -1,0 +1,70 @@
+"""Tests for the utils module."""
+
+import json
+from auvsi_suas.proto import interop_admin_api_pb2
+from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from google.protobuf import json_format
+
+gps_conversion_url = reverse('auvsi_suas:gps_conversion')
+
+
+class TestGpsConversion(TestCase):
+
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            'superuser', 'email@example.com', 'superpass')
+        self.superuser.save()
+
+    def test_not_authenticated(self):
+        """Tests that not authenticated return 403."""
+        response = self.client.post(gps_conversion_url)
+        self.assertEqual(403, response.status_code)
+
+    def test_not_admin(self):
+        """Tests that not admin return 403."""
+        user = User.objects.create_user('user', 'email@example.com',
+                                             'testpass')
+        user.save()
+        self.client.force_login(user)
+
+        response = self.client.post(gps_conversion_url)
+        self.assertEqual(403, response.status_code)
+
+    def test_invalid_request(self):
+        """Tests that invalid requests return 400."""
+        self.client.force_login(self.superuser)
+
+        response = self.client.post(gps_conversion_url)
+        self.assertEqual(400, response.status_code)
+
+        request_proto = interop_admin_api_pb2.GpsConversionRequest()
+        request_proto.latitude = 'ABC'
+        request_proto.longitude = 'DEF'
+
+        response = self.client.post(
+                gps_conversion_url,
+                json_format.MessageToJson(request_proto),
+                content_type='application/json')
+        self.assertEqual(400, response.status_code)
+
+
+    def test_conversion(self):
+        """Tests that it can convert a valid request."""
+        self.client.force_login(self.superuser)
+
+        request_proto = interop_admin_api_pb2.GpsConversionRequest()
+        request_proto.latitude = 'N38-08-46.57'
+        request_proto.longitude = 'W076-25-41.39'
+
+        response = self.client.post(
+                gps_conversion_url,
+                json_format.MessageToJson(request_proto),
+                content_type='application/json')
+        self.assertEqual(200, response.status_code)
+
+        response_proto = interop_admin_api_pb2.GpsConversionResponse()
+        json_format.Parse(response.content, response_proto)
+        self.assertAlmostEqual(response_proto.latitude, 38.146269, places=5)
+        self.assertAlmostEqual(response_proto.longitude, -76.428164, places=5)

--- a/server/config/requirements.txt
+++ b/server/config/requirements.txt
@@ -1,4 +1,5 @@
 Django>=1.11,<1.12
+LatLon23
 PyYAML # for loaddata
 django-pipeline
 django-sendfile

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -193,6 +193,7 @@ PIPELINE = {
                 'components/navigation.js',
                 'components/backend-service.js',
                 'components/team-status-controller.js',
+                'pages/gps-conversion-controller.js',
                 'pages/mission-dashboard-controller.js',
                 'pages/mission-list-controller.js',
                 'pages/odlc-review-controller.js',


### PR DESCRIPTION
Many of the mission parameters are determined using the string format of
GPS rather than the decimal format. Previously an offline CLI was used
to perform this conversion. To save the interop operator from knowing
how to use a command line and CLI, this pushes it into the web
interface.

For #315