### PR TITLE
Set uwsgi_read_timeout to 10min.

### DIFF
--- a/server/config/nginx.conf
+++ b/server/config/nginx.conf
@@ -7,6 +7,7 @@ server {
     server_name interop_server_wsgi;
     charset     utf-8;
     client_max_body_size 10M;
+    uwsgi_read_timeout 600s;
 
     location /static {
         alias /interop/server/static;


### PR DESCRIPTION
Scoring may take longer than the default timeout.

For #427.