### PR TITLE
Fix rate calculation. Fix KML output.

### DIFF
--- a/server/auvsi_suas/models/mission_evaluation_test.py
+++ b/server/auvsi_suas/models/mission_evaluation_test.py
@@ -303,8 +303,8 @@ class TestMissionEvaluation(TestCase):
         self.assertEqual(0.0,
                          feedback.waypoints[1].closest_for_scored_approach_ft)
 
-        self.assertAlmostEqual(0.5, feedback.uas_telemetry_time_max_sec)
-        self.assertAlmostEqual(1. / 6, feedback.uas_telemetry_time_avg_sec)
+        self.assertAlmostEqual(1.0, feedback.uas_telemetry_time_max_sec)
+        self.assertAlmostEqual(1.0, feedback.uas_telemetry_time_avg_sec)
 
         self.assertAlmostEqual(0.454, feedback.odlc.score_ratio, places=3)
 
@@ -358,7 +358,7 @@ class TestMissionEvaluation(TestCase):
                          feedback.waypoints[1].closest_for_scored_approach_ft)
 
         self.assertAlmostEqual(2.0, feedback.uas_telemetry_time_max_sec)
-        self.assertAlmostEqual(1.0, feedback.uas_telemetry_time_avg_sec)
+        self.assertAlmostEqual(2.0, feedback.uas_telemetry_time_avg_sec)
 
         self.assertAlmostEqual(0, feedback.odlc.score_ratio, places=3)
 
@@ -375,7 +375,7 @@ class TestMissionEvaluation(TestCase):
         self.assertAlmostEqual(0.7997777777777778, score.timeline.score_ratio)
         self.assertAlmostEqual(1, score.autonomous_flight.flight)
         self.assertAlmostEqual(0.5, score.autonomous_flight.waypoint_capture)
-        self.assertAlmostEqual(1, score.autonomous_flight.waypoint_accuracy)
+        self.assertAlmostEqual(0, score.autonomous_flight.waypoint_accuracy)
         self.assertAlmostEqual(
             0.1, score.autonomous_flight.safety_pilot_takeover_penalty)
         self.assertAlmostEqual(0,
@@ -383,7 +383,7 @@ class TestMissionEvaluation(TestCase):
         self.assertAlmostEqual(0.25,
                                score.autonomous_flight.things_fell_off_penalty)
         self.assertAlmostEqual(0.35, score.autonomous_flight.crashed_penalty)
-        self.assertAlmostEqual(0.25, score.autonomous_flight.score_ratio)
+        self.assertAlmostEqual(-0.25, score.autonomous_flight.score_ratio)
 
         self.assertAlmostEqual(0, score.object.characteristics)
         self.assertAlmostEqual(0, score.object.geolocation)
@@ -398,7 +398,7 @@ class TestMissionEvaluation(TestCase):
 
         self.assertAlmostEqual(0.8, score.operational_excellence.score_ratio)
 
-        self.assertAlmostEqual(0.5099777777777779, score.score_ratio)
+        self.assertAlmostEqual(0.20997777777777782, score.score_ratio)
 
     def test_evaluate_teams_specific_users(self):
         """Tests the evaluation of teams method with specific users."""

--- a/server/auvsi_suas/models/uas_telemetry.py
+++ b/server/auvsi_suas/models/uas_telemetry.py
@@ -85,22 +85,19 @@ class UasTelemetry(AccessLog):
         Args:
             logs: A sorted list of UasTelemetry logs.
         Returns:
-            A list containing the non-duplicate logs in the original list.
+            A sequence containing the non-duplicate logs in the original list.
         """
         # Check that logs were provided.
         if not logs:
             return logs
 
         # For each log, compare to previous. If different, add to output.
-        filtered = []
         prev_log = None
         for log in logs:
-            if prev_log is None or not prev_log.duplicate(log):
+            if not prev_log or not prev_log.duplicate(log):
                 # New unique log.
-                filtered.append(log)
+                yield log
                 prev_log = log
-
-        return filtered
 
     @classmethod
     def filter_bad(cls, logs):

--- a/server/auvsi_suas/models/uas_telemetry_test.py
+++ b/server/auvsi_suas/models/uas_telemetry_test.py
@@ -200,18 +200,18 @@ class TestUasTelemetryFilter(TestUasTelemetryBase):
 
     def test_no_logs(self):
         """Tests empty log."""
-        self.assertEqual(UasTelemetry.dedupe([]), [])
+        self.assertSequenceEqual(list(UasTelemetry.dedupe([])), [])
 
     def test_no_duplicates(self):
         """Tests no duplicates in list."""
         orig = [self.log1, self.log2, self.log3, self.log4]
-        self.assertEqual(UasTelemetry.dedupe(orig), orig)
+        self.assertSequenceEqual(list(UasTelemetry.dedupe(orig)), orig)
 
     def test_boundary_duplicates(self):
         """Tests duplicates on the bounds of the list."""
         orig = [self.log1, self.log1, self.log2, self.log2, self.log2]
         expect = [self.log1, self.log2]
-        self.assertEqual(UasTelemetry.dedupe(orig), expect)
+        self.assertSequenceEqual(list(UasTelemetry.dedupe(orig)), expect)
 
     def test_duplicates(self):
         orig = [
@@ -219,13 +219,13 @@ class TestUasTelemetryFilter(TestUasTelemetryBase):
             self.log4
         ]
         expect = [self.log1, self.log2, self.log3, self.log4]
-        self.assertEqual(UasTelemetry.dedupe(orig), expect)
+        self.assertSequenceEqual(list(UasTelemetry.dedupe(orig)), expect)
 
     def test_filter_bad(self):
         """Tests filter_bad()."""
         orig = [self.log1, self.log5]
         expect = [self.log1]
-        self.assertEqual(list(UasTelemetry.filter_bad(orig)), expect)
+        self.assertSequenceEqual(list(UasTelemetry.filter_bad(orig)), expect)
 
 
 class TestUasTelemetryInterpolate(TestUasTelemetryBase):


### PR DESCRIPTION
Fixes rate calculation that had an off-by-one error while indexing into
the logs which caused it to not include the measurement between the last
two logs.

Improves rate calculation and telemetry deduping to leverage iterator
rather than materializing as lists (loading all data into memory at
once).

Fixes KML output to only emit logs for the flight periods, not for all
of time.