### PR TITLE
Make /api/teams public. Add age & ID. Add to CLI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,20 @@ standard way: it creates the container and starts a pre-configured shell.
 sudo ./interop-client.sh run
 ```
 
+##### Get Teams
+
+The client image provides a script to request the status of teams from the
+interoperability server, and it can be executed from the container shell. The
+following shows how to execute it for the default testing user (`testuser`) if
+the interop server was at `10.10.130.2:8000`.
+
+```bash
+./tools/interop_cli.py \
+    --url http://10.10.130.2:8000 \
+    --username testuser \
+    teams
+```
+
 ##### Get Mission
 
 The client image provides a script to request mission details from the
@@ -402,11 +416,18 @@ client = client.Client(url='http://127.0.0.1:8000',
                        password='testpass')
 ```
 
+The following shows how to request the status of teams.
+
+```python
+teams = client.get_teams()
+print(teams)
+```
+
 The following shows how to request the mission details.
 
 ```python
 mission = client.get_mission(1)
-print mission
+print(mission)
 ```
 
 The following shows how to upload UAS telemetry.
@@ -624,6 +645,49 @@ HTTP/1.1 200 OK
 Set-Cookie: sessionid=9vepda5aorfdilwhox56zhwp8aodkxwi; expires=Mon, 17-Aug-2015 02:41:09 GMT; httponly; Max-Age=1209600; Path=/
 
 Login Successful.
+```
+
+#### Teams
+
+##### GET /api/teams
+
+This endpoint gets the status of teams. Returns a list of `TeamStatus` JSON
+formatted proto.
+
+Example Request:
+
+```http
+GET /api/teams HTTP/1.1
+Host: 192.168.1.2:8000
+Cookie: sessionid=9vepda5aorfdilwhox56zhwp8aodkxwi
+```
+
+Example Response:
+
+Note: This example reformatted for readability; actual response may be
+entirely on one line.
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+{
+  "team": {
+    "id": 2,
+    "username": "testuser",
+    "name": "Team Name",
+    "university": "Team University"
+  },
+  "inAir": false,
+  "telemetry": {
+    "latitude": 0.0,
+    "longitude": 0.0,
+    "altitude": 0.0,
+    "heading": 0.0
+  },
+  "telemetryId": "1278",
+  "telemetryAgeSec": 1.064382,
+  "telemetryTimestamp": "2019-10-05T20:42:23.643989+00:00"
+}
 ```
 
 #### Missions
@@ -1089,7 +1153,7 @@ Tutorials](https://docs.djangoproject.com/en/1.10/intro/).
 
 ```python
 # Print all mission objects.
-print MissionConfig.objects.all()
+print(MissionConfig.objects.all())
 
 # Create and save a GPS position.
 gpos = GpsPosition(latitudel=38.145335, longitude=-76.427512)

--- a/client/auvsi_suas/client/client.py
+++ b/client/auvsi_suas/client/client.py
@@ -118,6 +118,24 @@ class Client(object):
             raise InteropError(r)
         return r
 
+    def get_teams(self):
+        """GET the status of teams.
+
+        Returns:
+            List of TeamStatus objects for active teams.
+        Raises:
+            InteropError: Error from server.
+            requests.Timeout: Request timeout.
+            ValueError or AttributeError: Malformed response from server.
+        """
+        r = self.get('/api/teams')
+        teams = []
+        for team_dict in r.json():
+            team_proto = interop_api_pb2.TeamStatus()
+            json_format.Parse(json.dumps(team_dict), team_proto)
+            teams.append(team_proto)
+        return teams
+
     def get_mission(self, mission_id):
         """GET a mission by ID.
 
@@ -315,6 +333,15 @@ class AsyncClient(object):
         self.client = Client(url, username, password, timeout, max_concurrent,
                              max_retries)
         self.executor = ThreadPoolExecutor(max_workers=max_concurrent)
+
+    def get_teams(self):
+        """GET the status of teams.
+
+        Returns:
+            Future object which contains the return value or error from the
+            underlying Client.
+        """
+        return self.executor.submit(self.client.get_teams)
 
     def get_mission(self, mission_id):
         """GET a mission by ID.

--- a/client/auvsi_suas/client/client_test.py
+++ b/client/auvsi_suas/client/client_test.py
@@ -59,6 +59,15 @@ class TestClient(unittest.TestCase):
         self.client = Client(server, username, password)
         self.async_client = AsyncClient(server, username, password)
 
+    def test_get_teams(self):
+        """Tests getting team status."""
+        teams = self.client.get_teams()
+        async_teams = self.async_client.get_teams().result()
+        self.assertEqual(1, len(teams))
+        self.assertEqual(1, len(async_teams))
+        self.assertEqual('testuser', teams[0].team.username)
+        self.assertEqual('testuser', async_teams[0].team.username)
+
     def test_get_mission(self):
         """Test getting a mission."""
         mission = self.client.get_mission(1)

--- a/client/tools/interop_cli.py
+++ b/client/tools/interop_cli.py
@@ -18,6 +18,12 @@ from upload_odlcs import upload_odlcs
 logger = logging.getLogger(__name__)
 
 
+def teams(args, client):
+    teams = client.get_teams().result()
+    for team in teams:
+        print(json_format.MessageToJson(team))
+
+
 def mission(args, client):
     mission = client.get_mission(args.mission_id).result()
     print(json_format.MessageToJson(mission))
@@ -76,6 +82,9 @@ def main():
     parser.add_argument('--password', help='Password for interoperability.')
 
     subparsers = parser.add_subparsers(help='Sub-command help.')
+
+    subparser = subparsers.add_parser('teams', help='Get the status of teams.')
+    subparser.set_defaults(func=teams)
 
     subparser = subparsers.add_parser('mission', help='Get mission details.')
     subparser.set_defaults(func=mission)

--- a/client/tools/interop_cli_test.py
+++ b/client/tools/interop_cli_test.py
@@ -22,6 +22,14 @@ class InteropCliTestBase(unittest.TestCase):
         self.assertEqual(0, subprocess.call(args))
 
 
+class TestTeams(InteropCliTestBase):
+    """Test able to request statuses of teams."""
+
+    def test_get_teams(self):
+        """Test getting statuses of teams."""
+        self.assertCliOk(self.cli_base_args + ['teams'])
+
+
 class TestMissions(InteropCliTestBase):
     """Test able to request mission details."""
 

--- a/proto/interop_admin_api.proto
+++ b/proto/interop_admin_api.proto
@@ -4,36 +4,6 @@ syntax = "proto2";
 package auvsi_suas.proto;
 import "auvsi_suas/proto/interop_api.proto";
 
-// Identifier for a team.
-message TeamId {
-    // Interop username for the team.
-    optional string username = 1;
-
-    // Name of the team.
-    optional string name = 2;
-
-    // University the team represents.
-    optional string university = 3;
-}
-
-// Status of a team.
-message TeamStatus {
-    // ID of the team.
-    optional int32 id = 1;
-
-    // The team this status describes.
-    optional TeamId team = 2;
-
-    // Whether the team is marked in air by admin.
-    optional bool in_air = 3;
-
-    // Most recent telemetry position, if it exists.
-    optional Telemetry telemetry = 4;
-
-    // Timestamp of the telemetry position as ISO string.
-    optional string telemetry_timestamp = 5;
-}
-
 // Review details for an ODLC.
 message OdlcReview {
     // The ODLC being reviewed.

--- a/proto/interop_api.proto
+++ b/proto/interop_api.proto
@@ -13,6 +13,42 @@ message Credentials {
     optional string password = 2;
 }
 
+// Identifier for a team.
+message TeamId {
+    // The ID of the team.
+    optional int32 id = 1;
+
+    // Interop username for the team.
+    optional string username = 2;
+
+    // Name of the team.
+    optional string name = 3;
+
+    // University the team represents.
+    optional string university = 4;
+}
+
+// Status of a team.
+message TeamStatus {
+    // The team this status describes.
+    optional TeamId team = 1;
+
+    // Whether the team is marked in air by admin.
+    optional bool in_air = 2;
+
+    // Most recent telemetry position, if it exists.
+    optional Telemetry telemetry = 3;
+
+    // ID of the telemetry.
+    optional int64 telemetry_id = 4;
+
+    // Age of the telemetry (time since uploaded to interop).
+    optional double telemetry_age_sec = 5;
+
+    // Timestamp of the telemetry as an ISO string.
+    optional string telemetry_timestamp = 6;
+}
+
 // Details for a mission.
 message Mission {
     // Unique identifier for the mission.

--- a/server/auvsi_suas/views/teams_test.py
+++ b/server/auvsi_suas/views/teams_test.py
@@ -94,14 +94,14 @@ class TestTeamsView(TestCase):
         self.telem.save()
 
     def test_normal_user(self):
-        """Normal users not allowed access."""
+        """Normal users allowed access."""
         user = User.objects.create_user('testuser', 'email@example.com',
                                         'testpass')
         user.save()
         self.client.force_login(user)
 
         response = self.client.get(teams_url)
-        self.assertEqual(403, response.status_code)
+        self.assertEqual(200, response.status_code)
 
     def test_no_users(self):
         """No users results in empty list, no superusers."""
@@ -127,11 +127,13 @@ class TestTeamsView(TestCase):
         self.assertEqual(2, len(data))
 
         for user in data:
-            self.assertIn('id', user)
             self.assertIn('team', user)
+            self.assertIn('id', user['team'])
             self.assertIn('username', user['team'])
             self.assertIn('inAir', user)
             if 'telemetry' in user:
+                self.assertIn('telemetryId', user)
+                self.assertIn('telemetryAgeSec', user)
                 self.assertIn('telemetryTimestamp', user)
 
     def test_users_correct(self):
@@ -159,6 +161,8 @@ class TestTeamsView(TestCase):
             u'altitude': 0.0,
             u'heading': 90.0,
         }, user2['telemetry'])
+        self.assertEqual(int(user2['telemetryId']), self.telem.pk)
+        self.assertGreater(user2['telemetryAgeSec'], 0)
         self.assertEqual(user2['telemetryTimestamp'],
                          u'2016-10-01T00:00:00+00:00')
 


### PR DESCRIPTION
Makes the endpoint /api/teams public so that teams can use it for moving
obstacle avoidance.

Adds telemetry age so teams can extrapolate where the UAS is currently.

Adds telemetry ID so teams can dedupe the same telemetry message which
might otherwise indicate the UAS isn't moving.

Adds to the CLI so it's convenient for teams to access.

Fixes #450