### PR TITLE
Filter inactive users. Add mission to eval.

### DIFF
--- a/proto/interop_admin_api.proto
+++ b/proto/interop_admin_api.proto
@@ -56,17 +56,20 @@ message MultiUserMissionEvaluation {
 
 // Evaluation data for a mission.
 message MissionEvaluation {
+    // The mission which this evaluation describes.
+    optional int32 mission = 1;
+
     // The team which this evaluation describes.
-    optional TeamId team = 1;
+    optional TeamId team = 2;
 
     // Warnings generated during the evaluation process.
-    repeated string warnings = 2;
+    repeated string warnings = 3;
 
     // Feedback provided to the team.
-    optional MissionFeedback feedback = 3;
+    optional MissionFeedback feedback = 4;
 
     // Scoring data.
-    optional MissionScore score = 4;
+    optional MissionScore score = 5;
 }
 
 // Data which was basis for score, provided as feedback for the team.

--- a/server/auvsi_suas/models/mission_evaluation_test.py
+++ b/server/auvsi_suas/models/mission_evaluation_test.py
@@ -299,10 +299,11 @@ class TestMissionEvaluation(TestCase):
         """Smoke tests the evaluation of teams method."""
         mission_eval = mission_evaluation.evaluate_teams(self.mission)
 
-        # Contains user0 and user1
-        self.assertEqual(2, len(mission_eval.teams))
+        # Contains only user0 (user1 is inactive).
+        self.assertEqual(1, len(mission_eval.teams))
 
         user_eval = mission_eval.teams[0]
+        self.assertEqual(self.mission.pk, user_eval.mission)
         self.assertEqual(self.user0.username, user_eval.team.username)
         self.assertEqual(self.user0.first_name, user_eval.team.name)
         self.assertEqual(self.user0.last_name, user_eval.team.university)

--- a/server/auvsi_suas/views/missions_test.py
+++ b/server/auvsi_suas/views/missions_test.py
@@ -359,9 +359,8 @@ class TestEvaluateTeams(TestMissionsViewCommon):
         data = self.load_json(response)
         self.assertIn('teams', data)
         teams = data['teams']
-        self.assertEqual(len(teams), 2)
+        self.assertEqual(len(teams), 1)
         self.assertEqual('user0', teams[0]['team']['username'])
-        self.assertEqual('user1', teams[1]['team']['username'])
         self.assertIn('waypoints', teams[0]['feedback'])
 
     def test_evaluate_teams_specific_team(self):
@@ -383,7 +382,6 @@ class TestEvaluateTeams(TestMissionsViewCommon):
         self.assertEqual(response.status_code, 200)
         html_data = self.load_html(response)
         self.assertIn('user0', html_data)
-        self.assertIn('user1', html_data)
 
     def test_evaluate_teams_csv(self):
         """Tests the CSV method."""
@@ -391,11 +389,10 @@ class TestEvaluateTeams(TestMissionsViewCommon):
         response = self.client.get(evaluate_url(args=[self.mission.pk]))
         self.assertEqual(response.status_code, 200)
         csv_data = self.load_csv(response)
-        self.assertEqual(len(csv_data.split('\n')), 4)
+        self.assertEqual(len(csv_data.split('\n')), 3)
         self.assertIn('team', csv_data)
         self.assertIn('waypoints', csv_data)
         self.assertIn('user0', csv_data)
-        self.assertIn('user1', csv_data)
 
 
 class TestMissionDetailsView(TestMissionsViewCommon):

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -68,7 +68,7 @@ else
     yapf_args="--diff"
 fi
 
-echo "${files}" | xargs -i yapf ${yapf_args} "${repo}/{}"
+echo "${files}" | xargs -i yapf ${yapf_args} "{}"
 exit_code=$?
 
 if [[ ${exit_code} != 0 && ${inplace} == "" ]]; then


### PR DESCRIPTION
Filtering inactive users will make it possible to merge multi-mission
evaluations by catting the result.

Adds mission ID to the eval output so that state is maintained post
merging the outputs.

Fixes #448