### PR TITLE
Pin postgres version. Set postgres user/pass.

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -2,7 +2,10 @@ version: '3.2'
 
 services:
   interop-db:
-    image: postgres
+    image: postgres:9.6.17
+    environment:
+        POSTGRES_USER: postgres
+        POSTGRES_PASSWORD: postgres
     volumes:
       - ./volumes/var/lib/postgresql/data:/var/lib/postgresql/data
   interop-server:

--- a/server/interop-server.sh
+++ b/server/interop-server.sh
@@ -20,8 +20,15 @@ fi
 if [ "$1" == "create_db" ]
 then
     docker-compose run interop-server ./healthcheck.py --postgres_host interop-db --check_postgres
-    docker-compose run interop-server psql -h interop-db -U postgres -c "CREATE DATABASE auvsi_suas_db;"
+    docker-compose run interop-server psql "postgresql://postgres:postgres@interop-db" -c "CREATE DATABASE auvsi_suas_db;"
     docker-compose run interop-server ./manage.py migrate
+fi
+
+# Drops the database. Dangerous!
+if [ "$1" == "drop_db" ]
+then
+    docker-compose run interop-server ./healthcheck.py --postgres_host interop-db --check_postgres
+    docker-compose run interop-server psql "postgresql://postgres:postgres@interop-db" -c "DROP DATABASE auvsi_suas_db;"
 fi
 
 # Loads test data. Optional, only needs to be done once.

--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -73,11 +73,13 @@ TEMPLATES = [
 
 # Database
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
+# SECURITY WARNING: change the database superuser password!
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'auvsi_suas_db',
         'USER': 'postgres',
+        'PASSWORD': 'postgres',
         'CONN_MAX_AGE': None,
         'HOST': 'interop-db',
         'PORT': '5432',


### PR DESCRIPTION
A minor version upgrade made a backwards-incompatible change which broke
CI/CD and competitor use of server image. Pins the postgres image to a
specific version to prevent this from happening in the future.

Sets the username and password for the database superuser account, which
is now required to connect. Note for security this is preferrable to
POSTGRES_HOST_AUTH_METHOD, which would accept any connection that can
access the port, as we can change the password at competition to lockout
teams, similar to how we change the session tokens.

Fixes #470.