### PR TITLE
Mission creation automation scripts

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,12 @@
+# Running mission creation scripts
+```
+$ docker-compose up
+... new terminal ...
+$ docker-compose run interop-server python3 /interop/scripts/create_mission.py -m /interop/scripts/sample_mission.json
+```
+
+# Interacting with the server via curl
+```
+$ curl http://localhost:8000/api/login -d @scripts/test_login.json -c cookies.txt
+$ curl http://localhost:8000/api/missions/1 -b cookies.txt | tee mission.json
+```

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - ./volumes/mount:/mount
       - ./volumes/logs/uwsgi:/var/log/uwsgi
       - ./volumes/var/www/media/objects:/var/www/media/objects
+      - ./scripts:/interop/scripts
+
     ports:
       - "8000:80"
     depends_on:

--- a/server/scripts/create_mission.py
+++ b/server/scripts/create_mission.py
@@ -1,0 +1,108 @@
+import os
+import sys
+
+# Add server code to Python PATH for imports.
+sys.path.append('/interop/server')
+# Add environment variable to get Django settings file.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.settings")
+
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()
+
+import json
+
+from django.contrib.auth.models import User
+from auvsi_suas.models.fly_zone import FlyZone
+from auvsi_suas.models.gps_position import GpsPosition
+from auvsi_suas.models.mission_config import MissionConfig
+from auvsi_suas.models.stationary_obstacle import StationaryObstacle
+from auvsi_suas.models.waypoint import Waypoint
+
+
+def get_or_prompt_gpos(data, key):
+    pos = data.get(key, None)
+    if pos is None:
+        pos = {}
+        print("{} not found, please specify:".format(key))
+        pos["latitude"] = input("    Latitude: ")
+        pos["longitude"] = input("    Longitude: ")
+
+    lat = pos["latitude"]
+    lon = pos["longitude"]
+    print("Loaded {} at {}, {}".format(key, lat, lon))
+
+    gpos = GpsPosition(latitude=lat, longitude=lon)
+    gpos.save()
+    return gpos
+
+
+def load_waypoint_series(series, point_data):
+    for i, point in enumerate(point_data):
+        wpt = Waypoint(
+            latitude=point["latitude"],
+            longitude=point["longitude"],
+            altitude_msl=point.get("altitude", 0),
+            order=i + 1)
+        wpt.save()
+        series.add(wpt)
+
+
+def create_mission(data):
+    mission = MissionConfig()
+    mission.home_pos = get_or_prompt_gpos(data, "homePos")
+    mission.lost_comms_pos = get_or_prompt_gpos(data, "lostCommsPos")
+    mission.off_axis_odlc_pos = get_or_prompt_gpos(data, "offAxisOdlcPos")
+    mission.emergent_last_known_pos = get_or_prompt_gpos(
+        data, "emergentLastKnownPos")
+    mission.air_drop_pos = get_or_prompt_gpos(data, "airDropPos")
+    mission.ugv_drive_pos = get_or_prompt_gpos(data, "ugvDrivePos")
+
+    mission.save()
+
+    for flyZoneData in data.get("flyZones", []):
+        print("Loading fly zone")
+        bounds = FlyZone(
+            altitude_msl_min=flyZoneData["altitudeMin"],
+            altitude_msl_max=flyZoneData["altitudeMax"])
+        bounds.save()
+        load_waypoint_series(bounds.boundary_pts,
+                             flyZoneData["boundaryPoints"])
+        bounds.save()
+        mission.fly_zones.add(bounds)
+
+    print("Loading waypoints")
+    load_waypoint_series(mission.mission_waypoints, data.get("waypoints", []))
+    print("Loading search grid")
+    load_waypoint_series(mission.search_grid_points,
+                         data.get("searchGridPoints", []))
+    print("Loading air drop boundary")
+    load_waypoint_series(mission.air_drop_boundary_points,
+                         data.get("airDropBoundaryPoints", []))
+
+    for point in data.get("stationaryObstacles", []):
+        obs = StationaryObstacle(
+            latitude=point["latitude"],
+            longitude=point["longitude"],
+            cylinder_height=point["height"],
+            cylinder_radius=point["radius"])
+        obs.save()
+        mission.stationary_obstacles.add(obs)
+
+    mission.save()
+
+
+if __name__ == "__main__":
+    import json
+    import argparse
+
+    parser = argparse.ArgumentParser("Interop mission creation script")
+    parser.add_argument("-m", "--mission", help="Mission JSON file")
+
+    args = parser.parse_args()
+
+    data = {}
+    if args.mission is not None:
+        with open(args.mission, "r") as f:
+            data = json.load(f)
+
+    create_mission(data)

--- a/server/scripts/sample_mission.json
+++ b/server/scripts/sample_mission.json
@@ -1,0 +1,248 @@
+{
+  "homePos": {
+    "latitude": 38.145103,
+    "longitude": -76.427856
+  },
+  "lostCommsPos": {
+    "latitude": 38.144778,
+    "longitude": -76.429417
+  },
+  "flyZones": [
+    {
+      "altitudeMin": 100.0,
+      "altitudeMax": 750.0,
+      "boundaryPoints": [
+        {
+          "latitude": 38.1462694444444,
+          "longitude": -76.4281638888889
+        },
+        {
+          "latitude": 38.151625,
+          "longitude": -76.4286833333333
+        },
+        {
+          "latitude": 38.1518888888889,
+          "longitude": -76.4314666666667
+        },
+        {
+          "latitude": 38.1505944444444,
+          "longitude": -76.4353611111111
+        },
+        {
+          "latitude": 38.1475666666667,
+          "longitude": -76.4323416666667
+        },
+        {
+          "latitude": 38.1446666666667,
+          "longitude": -76.4329472222222
+        },
+        {
+          "latitude": 38.1432555555556,
+          "longitude": -76.4347666666667
+        },
+        {
+          "latitude": 38.1404638888889,
+          "longitude": -76.4326361111111
+        },
+        {
+          "latitude": 38.1407194444444,
+          "longitude": -76.4260138888889
+        },
+        {
+          "latitude": 38.1437611111111,
+          "longitude": -76.4212055555556
+        },
+        {
+          "latitude": 38.1473472222222,
+          "longitude": -76.4232111111111
+        },
+        {
+          "latitude": 38.1461305555556,
+          "longitude": -76.4266527777778
+        }
+      ]
+    }
+  ],
+  "waypoints": [
+    {
+      "latitude": 38.1446916666667,
+      "longitude": -76.4279944444445,
+      "altitude": 200.0
+    },
+    {
+      "latitude": 38.1461944444444,
+      "longitude": -76.4237138888889,
+      "altitude": 300.0
+    },
+    {
+      "latitude": 38.1438972222222,
+      "longitude": -76.42255,
+      "altitude": 400.0
+    },
+    {
+      "latitude": 38.1417722222222,
+      "longitude": -76.4251083333333,
+      "altitude": 400.0
+    },
+    {
+      "latitude": 38.14535,
+      "longitude": -76.428675,
+      "altitude": 300.0
+    },
+    {
+      "latitude": 38.1508972222222,
+      "longitude": -76.4292972222222,
+      "altitude": 300.0
+    },
+    {
+      "latitude": 38.1514944444444,
+      "longitude": -76.4313833333333,
+      "altitude": 300.0
+    },
+    {
+      "latitude": 38.1505333333333,
+      "longitude": -76.434175,
+      "altitude": 300.0
+    },
+    {
+      "latitude": 38.1479472222222,
+      "longitude": -76.4316055555556,
+      "altitude": 200.0
+    },
+    {
+      "latitude": 38.1443333333333,
+      "longitude": -76.4322888888889,
+      "altitude": 200.0
+    },
+    {
+      "latitude": 38.1433166666667,
+      "longitude": -76.4337111111111,
+      "altitude": 300.0
+    },
+    {
+      "latitude": 38.1410944444444,
+      "longitude": -76.4321555555556,
+      "altitude": 400.0
+    },
+    {
+      "latitude": 38.1415777777778,
+      "longitude": -76.4252472222222,
+      "altitude": 400.0
+    },
+    {
+      "latitude": 38.1446083333333,
+      "longitude": -76.4282527777778,
+      "altitude": 200.0
+    }
+  ],
+  "searchGridPoints": [
+    {
+      "latitude": 38.1444444444444,
+      "longitude": -76.4280916666667
+    },
+    {
+      "latitude": 38.1459444444444,
+      "longitude": -76.4237944444445
+    },
+    {
+      "latitude": 38.1439305555556,
+      "longitude": -76.4227444444444
+    },
+    {
+      "latitude": 38.1417138888889,
+      "longitude": -76.4253805555556
+    },
+    {
+      "latitude": 38.1412111111111,
+      "longitude": -76.4322361111111
+    },
+    {
+      "latitude": 38.1431055555556,
+      "longitude": -76.4335972222222
+    },
+    {
+      "latitude": 38.1441805555556,
+      "longitude": -76.4320111111111
+    },
+    {
+      "latitude": 38.1452611111111,
+      "longitude": -76.4289194444444
+    },
+    {
+      "latitude": 38.1444444444444,
+      "longitude": -76.4280916666667
+    }
+  ],
+  "offAxisOdlcPos": {
+    "latitude": 38.145111,
+    "longitude": -76.427861
+  },
+  "emergentLastKnownPos": {
+    "latitude": 38.145111,
+    "longitude": -76.427861
+  },
+  "airDropBoundaryPoints": [
+    {
+      "latitude": 38.1461666666667,
+      "longitude": -76.4266666666667
+    },
+    {
+      "latitude": 38.1463611111111,
+      "longitude": -76.4261666666667
+    },
+    {
+      "latitude": 38.1455833333333,
+      "longitude": -76.4260833333333
+    },
+    {
+      "latitude": 38.1454166666667,
+      "longitude": -76.4266111111111
+    }
+  ],
+  "airDropPos": {
+    "latitude": 38.145848,
+    "longitude": -76.426374
+  },
+  "ugvDrivePos": {
+    "latitude": 38.146152,
+    "longitude": -76.426396
+  },
+  "stationaryObstacles": [
+    {
+      "latitude": 38.146689,
+      "longitude": -76.426475,
+      "radius": 150.0,
+      "height": 750.0
+    },
+    {
+      "latitude": 38.142914,
+      "longitude": -76.430297,
+      "radius": 300.0,
+      "height": 300.0
+    },
+    {
+      "latitude": 38.149504,
+      "longitude": -76.43311,
+      "radius": 100.0,
+      "height": 750.0
+    },
+    {
+      "latitude": 38.148711,
+      "longitude": -76.429061,
+      "radius": 300.0,
+      "height": 750.0
+    },
+    {
+      "latitude": 38.144203,
+      "longitude": -76.426155,
+      "radius": 50.0,
+      "height": 400.0
+    },
+    {
+      "latitude": 38.146003,
+      "longitude": -76.430733,
+      "radius": 225.0,
+      "height": 500.0
+    }
+  ]
+}

--- a/server/scripts/test_login.json
+++ b/server/scripts/test_login.json
@@ -1,0 +1,1 @@
+{"username": "testuser", "password": "testpass"}


### PR DESCRIPTION
I saw a question on the google group a few days ago about setting up automation scripts for mission creation, so I thought I'd offer up one of the simple convenience scripts we use internally. It's a convenient script, and provides an easy starting point for creating further automation scripts.

The `create_mission.py` script takes a JSON file in the same format as the output from the `/mission/{id}` endpoint and creates a new mission, prompting for any missing required fields. I've included a full example mission in `sample_mission,json` for easy setup. The sample mission is identical to the sample data from the `test_utils` mission.