### PR TITLE
Switch hardcoded packages to find_packages()

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -44,7 +44,7 @@ if __name__ == '__main__':
         name='auvsi_suas',
         description='AUVSI SUAS interoperability client library.',
         license='Apache 2.0',
-        packages=['auvsi_suas'],
+        packages=setuptools.find_packages(),
         cmdclass = { 'clean': clean, 'build_py': build_py },
         install_requires=reqs,
     )  # yapf: disable


### PR DESCRIPTION
I found some issues with the subpackages (client, proto) not being properly installed with `python setup.py install`. Switching the hardcoded `packages=['auvsi-suas']`to setuptools.find_packages() fixes this, and nevertheless is good practice anyway!