### PR TITLE
Use /usr/bin/env in all shebangs

### DIFF
--- a/client/configure.sh
+++ b/client/configure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Configures the Interop Client for the Docker image build.
 
 CLIENT=$(dirname ${BASH_SOURCE[0]})

--- a/client/interop-client.sh
+++ b/client/interop-client.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Utility scripts.
 
 CLIENT=$(dirname ${BASH_SOURCE[0]})

--- a/server/interop-server.sh
+++ b/server/interop-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Utility scripts.
 
 SERVER=$(dirname ${BASH_SOURCE[0]})

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Deploys Docker containers to hub.
 
 set -e

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Format files in the repository.
 # Either all file, or only those changed sinced commit-ish.

--- a/tools/setup_tools.sh
+++ b/tools/setup_tools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Installs software for tools.
 
 TOOLS=$(dirname ${BASH_SOURCE[0]})


### PR DESCRIPTION
`interop-server.sh` doesn't run on NixOS (and I think probably not Mac but I can't confirm) because of the shebang being `#!/bin/bash` instead of `#!/usr/bin/env bash`. This switches all scripts' shebangs to use `/usr/bin/env`.