### PR TITLE
Upgrade pymavlink to 2.4.14.

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -4,6 +4,6 @@ futures
 lxml
 nose
 protobuf>=3.2
-pymavlink==2.4.8
+pymavlink==2.4.14
 pyserial
 requests


### PR DESCRIPTION
Upgrade version to support Python 3.9.

Fixes #490.